### PR TITLE
Macro simplification

### DIFF
--- a/Klipper macro/klicky-probe.cfg
+++ b/Klipper macro/klicky-probe.cfg
@@ -407,6 +407,13 @@ gcode:
             { action_respond_info("Homing Z") }
         {% endif %}
 
+        {% if (not 'z' in printer.toolhead.homed_axes) %}
+            {% if V %}
+                { action_respond_info("Resetting Z position to zero") }
+            {% endif %}
+            SET_KINEMATIC_POSITION Z=0
+        {% endif %}
+
         # if probe is configured as endstop, attach it
         {% if printer['configfile'].config["stepper_z"]["endstop_pin"] == 'probe:z_virtual_endstop' %}
             Attach_Probe

--- a/Klipper macro/klicky-probe.cfg
+++ b/Klipper macro/klicky-probe.cfg
@@ -1,5 +1,5 @@
 # This macro was provided by discord user Garrettwp to whom i give my thanks for sharing it with me.
-# I have tweaked it a bit.
+# I have tweaked it a lot.
 #
 # this macro is  based on the great Annex magprobe dockable probe macros "#Originally developed by Mental, modified for better use on K-series printers by RyanG and Trails"
 # that macro can be found here https://github.com/Annex-Engineering/Annex-Engineering_Other_Printer_Mods/blob/master/All_Printers/Microswitch_Probe/Klipper_Macros/dockable_probe_macros.cfg
@@ -9,6 +9,8 @@
 [gcode_macro User_Variables]
 variable_verbose:               True  # Enable verbose output
 variable_travel_speed:          200   # how fast all other travel moves will be performed when running these macros
+variable_dock_speed:            10    # how fast should the toolhead move when docking the probe for the final movement
+variable_release_speed:         100    # how fast should the toolhead move to release the hold of the magnets after docking
 variable_z_drop_speed:          20    # how fast the z will lower when moving to the z location to clear the probe
 variable_home_z_height:         15    # Z when homing
 
@@ -31,6 +33,11 @@ variable_docklocation_x:        112   # X Dock position
 variable_docklocation_y:        305   # Y Dock position
 variable_docklocation_z:        15    # Z dock position
 variable_dockarmslenght:        30    # Dock arms lenght, toolhead movement necessary to clear the dock arms
+
+#Umbilical to help untangle the umbilical in difficult situations
+variable_umbilical_x:           15    #X umbilical position
+variable_umbilical_y:           15    #Y umbilical position
+variable_umbilical:             False #should we untabgle the umbilical
 
 # Do not modify below
 gcode:
@@ -67,27 +74,11 @@ gcode:
 
 
 [gcode_macro Homing_Variables]
-variable_homed_x:                   False
-variable_homed_y:                   False
-variable_homed_z:                   False
-variable_homing:                    False
-variable_homed:                     False
-default_parameter_axis:
 default_parameter_reset:            0
 gcode:
     {% set R  = params.RESET %}
 
-    # if called with an axis in the parameters, set the axis to "true"
-    {% if 'AXIS' in params %}
-        SET_GCODE_VARIABLE MACRO=Homing_Variables VARIABLE=homed_{ AXIS.lower() } VALUE={ True }
-    {% endif %}
-
     {% if R %}
-        SET_GCODE_VARIABLE MACRO=Homing_Variables VARIABLE=homed_x   VALUE={ False }
-        SET_GCODE_VARIABLE MACRO=Homing_Variables VARIABLE=homed_y   VALUE={ False }
-        SET_GCODE_VARIABLE MACRO=Homing_Variables VARIABLE=homed_z   VALUE={ False }
-        SET_GCODE_VARIABLE MACRO=Homing_Variables VARIABLE=homing    VALUE={ False }
-        SET_GCODE_VARIABLE MACRO=Homing_Variables VARIABLE=homed     VALUE={ False }
         SET_GCODE_VARIABLE MACRO=Probe_Variables VARIABLE=probe_lock VALUE={ False }
    {% endif %}
 
@@ -95,11 +86,6 @@ gcode:
 # Attach Probe Routine
 [gcode_macro Attach_Probe]
 gcode:
-    # Get homing state
-    {% set H = printer["gcode_macro Homing_Variables"].homing %}
-    {% set Hx = printer["gcode_macro Homing_Variables"].homed_x %}
-    {% set Hy = printer["gcode_macro Homing_Variables"].homed_y %}
-    {% set Hz = printer["gcode_macro Homing_Variables"].homed_z %}
     # Get probe attach status
     {% set P = printer["gcode_macro Probe_Variables"].probe_attached %}
     {% set L = printer["gcode_macro Probe_Variables"].probe_lock %}
@@ -115,7 +101,7 @@ gcode:
     {% set St = printer["gcode_macro User_Variables"].travel_speed * 60    %}
 
     # if x and y are not homed
-    {% if not (Hx and Hy) %}
+  {% if not 'xy' in printer.toolhead.homed_axes %}
         { action_raise_error("Must Home X and Y Axis First!") }
 
     # If probe not attached and locked
@@ -125,19 +111,19 @@ gcode:
         {% endif %}
         G90
 
-        {% if (not Hz) %}
+        {% if (not 'z' in printer.toolhead.homed_axes) %}
             {% if V %}
                 { action_respond_info("Resetting Z position to zero") }
             {% endif %}
             SET_KINEMATIC_POSITION Z=0
         {% endif %}
 
-        {% if (not Hz or printer.toolhead.position.z < Hzh) %}
+        {% if (printer.toolhead.position.z < Hzh) %}
             G1 Z{Hzh} F1200
         {% endif %}
 
-        # Used to give the umbilical a better path to follow and coil properly if dock is tight in space
-        G1 X15 Y15 Z{Hzh} F{St}
+        Umbilical_Path
+
         # Probe entry location
         G1 X{Dx} Y{Dy|int - Da|int} Z{Hzh} F{St}
         #lower to Z dock
@@ -148,11 +134,7 @@ gcode:
         G1 X{Dx} Y{Dy|int - Da|int} F6000
         #Go to Z safe distance
         G1 Z{Hzh} F600
-        # If not homing, park toolhead
-        {% if not H %}
-            # Park tool head
-            Park_Toolhead
-        {% endif %}
+        Park_Toolhead
 
         CheckProbe action=attach
 
@@ -162,24 +144,22 @@ gcode:
         {% endif %}
 
         # Probe attached, do nothing
+    CheckProbe action=query
 
     {% else %}
         {% if V %}
             { action_respond_info("Probe already attached!") }
         {% endif %}
-    {% endif %}
 
+    # Probe attached, do nothing
     CheckProbe action=query
+
+    {% endif %}
 
 
 # Dock Probe Routine
 [gcode_macro Dock_Probe]
 gcode:
-    # Get Homing status
-    {% set H = printer["gcode_macro Homing_Variables"].homing %}
-    {% set Hx = printer["gcode_macro Homing_Variables"].homed_x %}
-    {% set Hy = printer["gcode_macro Homing_Variables"].homed_y %}
-    {% set Hz = printer["gcode_macro Homing_Variables"].homed_z %}
     # Get probe attach status
     {% set P = printer["gcode_macro Probe_Variables"].probe_attached %}
     {% set L = printer["gcode_macro Probe_Variables"].probe_lock %}
@@ -193,10 +173,13 @@ gcode:
     {% set Hzh = printer["gcode_macro User_Variables"].home_z_height|float %}
     # Set speed
     {% set St = printer["gcode_macro User_Variables"].travel_speed * 60    %}
+    {% set Sd = printer["gcode_macro User_Variables"].dock_speed * 60    %}
+    {% set Sr = printer["gcode_macro User_Variables"].release_speed * 60    %}
+    {% set Sz = printer["gcode_macro User_Variables"].z_drop_speed * 60    %}
 
-    # if x and y are not homed
-    {% if not (Hx and Hx) %}
-        { action_raise_error("Must Home X and Y Axis First!") }
+
+  {% if not 'xyz' in printer.toolhead.homed_axes %}
+        { action_raise_error("Must Home X, Y and Z Axis First!") }
 
     # If probe not attached and not locked
     {% elif P and not L %}
@@ -205,28 +188,24 @@ gcode:
         {% endif %}
         G90
 
-        {% if (not Hz or printer.toolhead.position.z < Dz) %}
-            G1 Z{Dz} F1200
+        {% if (printer.toolhead.position.z < Hzh) %}
+            G1 Z{Hzh} F{Sz}
         {% endif %}
 
-        # Used to give the umbilical a better path to follow and coil properly if dock is in tight space
-        G1 X15 Y15 Z{Hzh} F{St}
+        Umbilical_Path
+
         # Probe entry location
         G1 X{Dx} Y{Dy|int - Da|int} Z{Hzh} F{St}
         #lower to Z dock
-        G1 Z{Dz} F600
+        G1 Z{Dz} F{Sz}
         # Drop Probe to Probe location
-        G1 X{Dx} Y{Dy} F1800
+        G1 X{Dx} Y{Dy} F{Sd}
         # Probe decoupling
-        G1 X{Dx|int + 40} Y{Dy} F6000
+        G1 X{Dx|int + 40} Y{Dy} F{Sr}
         #Go to Z safe distance
-        G1 X{Dx|int + 40} Y{Dy|int - 5} Z{Hzh} F1800
+        G1 X{Dx|int + 40} Y{Dy|int - 5} Z{Hzh} F{St}
 
-        # If not homing, park toolhead
-        {% if not H %}
-            # Park tool head
-            Park_Toolhead
-        {% endif %}
+        Park_Toolhead
 
         CheckProbe action=dock
 
@@ -236,14 +215,19 @@ gcode:
         {% endif %}
 
         # Probe docked, do nothing
+    CheckProbe action=query
 
     {% else %}
         {% if V %}
             { action_respond_info("Probe already docked!") }
         {% endif %}
+
+        # Probe docked, do nothing
+    CheckProbe action=query
+
     {% endif %}
 
-    CheckProbe action=query
+
 
 
 # Quad Gantry Level
@@ -261,7 +245,6 @@ gcode:
     _QUAD_GANTRY_LEVEL {% for p in params
             %}{'%s=%s' % (p, params[p])}{%
             endfor %}
-    G28 Z0
     Dock_Probe
 
 
@@ -325,15 +308,17 @@ gcode:
 [gcode_macro PROBE_CALIBRATE]
 rename_existing:             _PROBE_CALIBRATE
 gcode:
+    SAVE_GCODE_STATE NAME=original_nozzle_location  #store current nozzle location
+
     CheckProbe action=query
-  Attach_Probe
+    Attach_Probe
 
     _PROBE_CALIBRATE {% for p in params
             %}{'%s=%s' % (p, params[p])}{%
            endfor %}
 
-  SAVE_GCODE_STATE NAME=original_nozzle_location  #store current nozzle location
-    Dock_Probe
+  Dock_Probe
+
     RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1  #restore current nozzle location
 
 
@@ -341,7 +326,7 @@ gcode:
 [gcode_macro PROBE_ACCURACY]
 rename_existing:             _PROBE_ACCURACY
 gcode:
-  SAVE_GCODE_STATE NAME=original_nozzle_location  #store current nozzle location
+    SAVE_GCODE_STATE NAME=original_nozzle_location  #store current nozzle location
     CheckProbe action=query
     Attach_Probe
 
@@ -357,14 +342,13 @@ gcode:
 [force_move]
 enable_force_move: True
 
-# Homeing Override
+# Homing Override
 [homing_override]
 axes:                             xyz
 gcode:
     # collect user state variables
     User_Variables
     {% set V = printer["gcode_macro User_Variables"].verbose %}
-    SET_GCODE_VARIABLE MACRO=Homing_Variables VARIABLE=homing VALUE={ True }
 
     CheckProbe action=query
 
@@ -372,7 +356,7 @@ gcode:
     {% set X, Y, Z = False, False, False %}
 
     # which axes have been requested for homing
-    {% if   not 'X' in params
+    {% if not 'X' in params
         and not 'Y' in params
         and not 'Z' in params %}
 
@@ -407,8 +391,6 @@ gcode:
             { action_respond_info("Homing X") }
         {% endif %}
         G28 X0
-        # set X axis as homed
-        Homing_Variables axis=X
     {% endif %}
 
     # Home y
@@ -417,8 +399,6 @@ gcode:
             { action_respond_info("Homing Y") }
         {% endif %}
         G28 Y0
-        # set Y axis as homed
-        Homing_Variables axis=Y
     {% endif %}
 
     # Home z
@@ -433,21 +413,31 @@ gcode:
         {% endif %}
 
         Home_Z
-        # set Z axis as homed
-        Homing_Variables axis=Z
+
 
         # if probe is configured as endstop, dock it
         {% if printer['configfile'].config["stepper_z"]["endstop_pin"] == 'probe:z_virtual_endstop' %}
             Dock_Probe
         {% endif %}
     {% endif %}
-
-    CheckProbe action=query
-
-    SET_GCODE_VARIABLE MACRO=Homing_Variables VARIABLE=homing VALUE={ False }
+  CheckProbe action=query
 
     # park the toolhead
     Park_Toolhead
+
+# umbilical path setup
+[gcode_macro Umbilical_Path]
+gcode:
+    {% set Ux = printer["gcode_macro User_Variables"].umbilical_x %}
+    {% set Uy = printer["gcode_macro User_Variables"].umbilical_y %}
+    {% set U = printer["gcode_macro User_Variables"].umbilical    %}
+    {% set Hzh = printer["gcode_macro User_Variables"].home_z_height|float %}
+    {% set St = printer["gcode_macro User_Variables"].travel_speed * 60    %}
+
+    {% if U %}
+        # Used to give the umbilical a better path to follow and coil properly if dock is tight in space
+        G1 X{Ux} Y{Uy} Z{Hzh} F{St}
+    {% endif %}
 
 
 # Home Z Routine
@@ -462,8 +452,8 @@ gcode:
     {% set Hy = printer["gcode_macro Homing_Variables"].homed_y            %}
 
     # if x and y are not homed yet, raise error
-    {% if not (Hx and Hy) %}
-        { action_raise_error("X and Y not homed!") }
+    {% if not 'xy' in printer.toolhead.homed_axes %}
+        { action_raise_error("Must Home X and Y Axis First!") }
 
     {% else %}
         # move tool to safe homing position and home Z axis
@@ -517,22 +507,6 @@ gcode:
         { action_raise_error("Probe attach failed!") }
     {% endif %}
 
-# Override M84 to reset homing state if motors are disabled.
-[gcode_macro M84]
-rename_existing:             M84.1
-gcode:
-    Homing_Variables reset=1
-    M84.1
-
-
-# Override M18 to reset homing state if motors are disabled.
-[gcode_macro M18]
-rename_existing:             M18.1
-gcode:
-    Homing_Variables reset=1
-    M18.1
-
-
 # Park Toolhead Routine
 [gcode_macro Park_Toolhead]
 gcode:
@@ -541,13 +515,9 @@ gcode:
     {% set Py = printer["gcode_macro User_Variables"].parkposition_y %}
     {% set Pz = printer["gcode_macro User_Variables"].parkposition_z %}
     {% set St = printer["gcode_macro User_Variables"].travel_speed * 60 %}
-    {% set H = printer["gcode_macro Homing_Variables"].homing %}
-    {% set Hx = printer["gcode_macro Homing_Variables"].homed_x %}
-    {% set Hy = printer["gcode_macro Homing_Variables"].homed_y %}
-    {% set Hz = printer["gcode_macro Homing_Variables"].homed_z %}
     {% set V = printer["gcode_macro User_Variables"].verbose %}
 
-    {% if (P and Hx and Hy and Hz) %}
+    {% if (P and 'xyz' in printer.toolhead.homed_axes) %}
         {% if V %}
             { action_respond_info("Parking Toolhead") }
         {% endif %}


### PR DESCRIPTION
Merged the macro simplification, it does not require the user to change the homing_override if he does not need the probe as a Z endstop