### PR TITLE
Fix potential crash on PROBE_ACCURACY and PROBE_CALIBRATE

### DIFF
--- a/Klipper macro/klicky-probe.cfg
+++ b/Klipper macro/klicky-probe.cfg
@@ -330,34 +330,38 @@ gcode:
 [gcode_macro PROBE_CALIBRATE]
 rename_existing:             _PROBE_CALIBRATE
 gcode:
-    SAVE_GCODE_STATE NAME=original_nozzle_location  #store current nozzle location
-
+    # Store the original nozzle location
+    SAVE_GCODE_STATE NAME=original_nozzle_location
+    
     CheckProbe action=query
     Attach_Probe
 
+    # Restore nozzle location to probe the right place
+    RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1
     _PROBE_CALIBRATE {% for p in params
             %}{'%s=%s' % (p, params[p])}{%
            endfor %}
 
-  Dock_Probe
-
-    RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1  #restore current nozzle location
+    Dock_Probe
 
 
 # Probe Accuracy
 [gcode_macro PROBE_ACCURACY]
 rename_existing:             _PROBE_ACCURACY
 gcode:
-    SAVE_GCODE_STATE NAME=original_nozzle_location  #store current nozzle location
+    # Store the original nozzle location
+    SAVE_GCODE_STATE NAME=original_nozzle_location
+
     CheckProbe action=query
     Attach_Probe
 
+    # Restore nozzle location to probe the right place
+    RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1
     _PROBE_ACCURACY {% for p in params
             %}{'%s=%s' % (p, params[p])}{%
            endfor %}
 
     Dock_Probe
-    RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1  #restore current nozzle location
 
 
 # enable to SET_KINEMATIC_POSITION for Z hop

--- a/Klipper macro/klicky-probe.cfg
+++ b/Klipper macro/klicky-probe.cfg
@@ -330,38 +330,60 @@ gcode:
 [gcode_macro PROBE_CALIBRATE]
 rename_existing:             _PROBE_CALIBRATE
 gcode:
-    # Store the original nozzle location
+    {% set Hzh = printer["gcode_macro User_Variables"].home_z_height|float %}
+    {% set Sz = printer["gcode_macro User_Variables"].z_drop_speed * 60 %}
+    {% set St = printer["gcode_macro User_Variables"].travel_speed %}
+
+    # Go to Z safe distance before saving location in order to
+    # avoid crashing the probe on the bed when coming back
+    G1 Z{Hzh} F{Sz}
+    M400 # mandatory to save the new safe position
     SAVE_GCODE_STATE NAME=original_nozzle_location
     
     CheckProbe action=query
     Attach_Probe
 
     # Restore nozzle location to probe the right place
-    RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1
+    RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1 MOVE_SPEED={St}
+    
     _PROBE_CALIBRATE {% for p in params
             %}{'%s=%s' % (p, params[p])}{%
            endfor %}
 
     Dock_Probe
 
+    # Restore nozzle location again at the end
+    RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1 MOVE_SPEED={St}
+
 
 # Probe Accuracy
 [gcode_macro PROBE_ACCURACY]
 rename_existing:             _PROBE_ACCURACY
 gcode:
-    # Store the original nozzle location
+    {% set Hzh = printer["gcode_macro User_Variables"].home_z_height|float %}
+    {% set Sz = printer["gcode_macro User_Variables"].z_drop_speed * 60 %}
+    {% set St = printer["gcode_macro User_Variables"].travel_speed %}
+
+    # Go to Z safe distance before saving location in order to
+    # avoid crashing the probe on the bed when coming back
+    G1 Z{Hzh} F{Sz}
+    M400 # mandatory to save the new safe position
     SAVE_GCODE_STATE NAME=original_nozzle_location
 
     CheckProbe action=query
     Attach_Probe
 
     # Restore nozzle location to probe the right place
-    RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1
+    RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1 MOVE_SPEED={St}
+
     _PROBE_ACCURACY {% for p in params
             %}{'%s=%s' % (p, params[p])}{%
            endfor %}
 
     Dock_Probe
+
+    # Restore nozzle location again at the end
+    RESTORE_GCODE_STATE NAME=original_nozzle_location MOVE=1 MOVE_SPEED={St}
 
 
 # enable to SET_KINEMATIC_POSITION for Z hop


### PR DESCRIPTION
Hello,

Thank you for this mod, it's soooo better than my Omron !

Here is a little modification I had to do to fix a crash when doing PROBE_CALIBRATE or PROBE_ACCURACY : the head was attaching the probe and then do the probe accuracy in front of the dock. In my case by bed was a little bit too far and this resulted in a crash.

In order to get the correct behavior, you need to RESTORE_GCODE_STATE "before" doing the _PROBE_ACCURACY or _PROBE_CALIBRATE and this was corrected.

I also added more safety by going at a safe Z distance before saving the original position. This to avoid crashing the probe on the bed when coming back to the original position (in case you do the PROBE_CALIBRATE at 1mm of the bed for example).

Feel free to comment, I can make change to adapt it better to your code and you can also contact me on Discord if needed :)