### PR TITLE
Correct positioning of the magnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It is not necessary any soldering, the AB mount wires are connected with pressur
   <img src="/Photos/probe_v1_underside.jpg" width="350" />
   <img src="/Photos/AB_Mount_wiring_complete.jpg" width="350" /> 
 </p>
-The magnet recommended installation is that the two magnets that attach to the microswitch are installed with the same polarity, the 3rd magnet should have the inverse polarity.
+The three magnets that attach to the microswitch must be installed with the same polarity, alternating magnetic fields will result in a slow but sure demagnetization of the magnets.
 It is also recommended to glue the magnets in place, superglue is good.
 
 You will need to add macros to klipper to be able to dock and undock the probe as necessary to do the Endstop (if necessary) and Quad Gantry Level, it is in the Klipper Macro directory.


### PR DESCRIPTION
Polarity reversal through decaying alternating magnetic field for the distribution of the magnetic domain magnetization direction will result in a demagnetization of the magnets.
Friction will accelerate this process.
To prevent this issue, the three magnets must be installed with the same polarity thus creating a single coherent magnetic domain.
Tested in production, works well on multiple printers.