### PR TITLE
Fix syntax in parameter loop

### DIFF
--- a/Klipper macro/klicky-probe-for v1.8.cfg
+++ b/Klipper macro/klicky-probe-for v1.8.cfg
@@ -253,7 +253,7 @@ gcode:
 #    Attach_Probe
 #
 #    _QUAD_GANTRY_LEVEL {% for p in params
-#            %}{'%s=%s' % (p, params[p])}{%
+#            %}{'%s=%s ' % (p, params[p])}{%
 #            endfor %}
 #			
 #    Dock_Probe
@@ -272,7 +272,7 @@ gcode:
    Attach_Probe
 
    _Z_TILT_ADJUST {% for p in params
-         %}{'%s=%s' % (p, params[p])}{%
+         %}{'%s=%s ' % (p, params[p])}{%
         endfor %}
    Dock_Probe
    G28 Z0
@@ -291,7 +291,7 @@ gcode:
    Attach_Probe
 
    _SCREWS_TILT_CALCULATE {% for p in params
-         %}{'%s=%s' % (p, params[p])}{%
+         %}{'%s=%s ' % (p, params[p])}{%
         endfor %}
 
    Dock_Probe
@@ -309,7 +309,7 @@ gcode:
     Attach_Probe
 
     _BED_MESH_CALIBRATE {% for p in params
-           %}{'%s=%s' % (p, params[p])}{%
+           %}{'%s=%s ' % (p, params[p])}{%
           endfor %}
 
     Dock_Probe
@@ -336,7 +336,7 @@ gcode:
     RESTORE_GCODE_STATE NAME=_original_nozzle_location MOVE=1 MOVE_SPEED={St}
     
     _PROBE_CALIBRATE {% for p in params
-            %}{'%s=%s' % (p, params[p])}{%
+            %}{'%s=%s ' % (p, params[p])}{%
            endfor %}
 
     Dock_Probe
@@ -364,7 +364,7 @@ gcode:
     RESTORE_GCODE_STATE NAME=_original_nozzle_location MOVE=1 MOVE_SPEED={St}
 
     _PROBE_ACCURACY {% for p in params
-            %}{'%s=%s' % (p, params[p])}{%
+            %}{'%s=%s ' % (p, params[p])}{%
            endfor %}
 
     Dock_Probe

--- a/Klipper macro/klicky-probe.cfg
+++ b/Klipper macro/klicky-probe.cfg
@@ -272,7 +272,7 @@ gcode:
     Attach_Probe
 
     _QUAD_GANTRY_LEVEL {% for p in params
-            %}{'%s=%s' % (p, params[p])}{%
+            %}{'%s=%s ' % (p, params[p])}{%
             endfor %}
     Dock_Probe
 
@@ -290,7 +290,7 @@ gcode:
 #    Attach_Probe
 #
 #    _Z_TILT_ADJUST {% for p in params
-#          %}{'%s=%s' % (p, params[p])}{%
+#          %}{'%s=%s ' % (p, params[p])}{%
 #         endfor %}
 #    G28 Z0
 #    Dock_Probe
@@ -309,7 +309,7 @@ gcode:
 #    Attach_Probe
 #
 #    _SCREWS_TILT_CALCULATE {% for p in params
-#          %}{'%s=%s' % (p, params[p])}{%
+#          %}{'%s=%s ' % (p, params[p])}{%
 #         endfor %}
 #
 #    Dock_Probe
@@ -327,7 +327,7 @@ gcode:
     Attach_Probe
 
     _BED_MESH_CALIBRATE {% for p in params
-           %}{'%s=%s' % (p, params[p])}{%
+           %}{'%s=%s ' % (p, params[p])}{%
           endfor %}
 
     Dock_Probe
@@ -354,7 +354,7 @@ gcode:
     RESTORE_GCODE_STATE NAME=_original_nozzle_location MOVE=1 MOVE_SPEED={St}
     
     _PROBE_CALIBRATE {% for p in params
-            %}{'%s=%s' % (p, params[p])}{%
+            %}{'%s=%s ' % (p, params[p])}{%
            endfor %}
 
     Dock_Probe
@@ -384,7 +384,7 @@ gcode:
     RESTORE_GCODE_STATE NAME=_original_nozzle_location MOVE=1 MOVE_SPEED={St}
 
     _PROBE_ACCURACY {% for p in params
-            %}{'%s=%s' % (p, params[p])}{%
+            %}{'%s=%s ' % (p, params[p])}{%
            endfor %}
 
     Dock_Probe


### PR DESCRIPTION
Fix syntax to separate the parameter in the loop, just adding a space in the formatting string