### PR TITLE
add missing G90 to _Home_Z

### DIFF
--- a/Klipper_macro/klicky-probe.cfg
+++ b/Klipper_macro/klicky-probe.cfg
@@ -595,6 +595,7 @@ gcode:
 
         # move tool to safe homing position and home Z axis
         # location of z endstop
+		G90
         G1 X{Zx} Y{Zy} Z{Hzh} F{St}
         G28 Z0
         G1 Z{Hzh} F{Sz}


### PR DESCRIPTION
If G28, G28 Z, or _Home_Z is attempted when the printer is in relative mode, it fails with a "Move out of range" error. 

I found that a G90 was missing in the _Home_Z macro.