### PR TITLE
Variable_rotated_probe and Z_TILT macro override

### DIFF
--- a/Klipper_macro/klicky-probe.cfg
+++ b/Klipper_macro/klicky-probe.cfg
@@ -42,6 +42,8 @@ variable_parkposition_x:        125
 variable_parkposition_y:        125
 variable_parkposition_z:        30
 
+variable_rotated_probe:         False    # for when the probe is attached with X movement rather than Y movement, such as with the AnnexEngineering's Gasherbrum-K3
+
 # Do not modify below
 gcode:
     {% set Mx = printer['configfile'].config["stepper_x"]["position_max"]|float %}
@@ -65,13 +67,6 @@ gcode:
         SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=z_endstop_x VALUE={ (Mx * 0.5) - Ox }
         SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=z_endstop_y VALUE={ (My * 0.5) - Oy }
     {% endif %}
-# This macro was provided by discord user Garrettwp to whom i give my thanks for sharing it with me.
-# I have tweaked it a lot.
-#
-# this macro is  based on the great Annex magprobe dockable probe macros "#Originally developed by Mental, modified for better use on K-series printers by RyanG and Trails"
-# that macro can be found here https://github.com/Annex-Engineering/Annex-Engineering_Other_Printer_Mods/blob/master/All_Printers/Microswitch_Probe/Klipper_Macros/dockable_probe_macros.cfg
-#
-# by standing on the shoulders of giants, lets see if we can see further
 
 [gcode_macro _Probe_Variables]
 variable_probe_attached:            False
@@ -144,6 +139,7 @@ gcode:
     {% set L = printer["gcode_macro _Probe_Variables"].probe_lock %}
     {% set V = printer["gcode_macro _User_Variables"].verbose %}
     # Get Docking location
+    {% set Ro = printer["gcode_macro _User_Variables"].rotated_probe %}
     {% set Mx = printer["gcode_macro _User_Variables"].dockmove_x|default(0) %}
     {% set My = printer["gcode_macro _User_Variables"].dockmove_y|default(0)  %}
     {% set Mz = printer["gcode_macro _User_Variables"].dockmove_z|default(0)  %}
@@ -167,11 +163,19 @@ gcode:
 
     #if there is no undock movement, assume older behavior
     {% if Mx == My == Mz == 0 %}
-        {% set Mx = 40 %}
+        {% if Ro %}
+            {% set My = -40 %}
+        {% else %}
+            {% set Mx = 40 %}
+        {% endif %}
     {% endif %}
     #if there is no Attach movement, assume older behavior
     {% if Ax == Ay == Az == 0 %}
-        {% set Ay = Da %}
+        {% if Ro %}
+            {% set Ax = -Da %}
+        {% else %}
+            {% set Ay = Da %}
+        {% endif %}
     {% endif %}
 
     # if x and y are not homed
@@ -275,6 +279,7 @@ gcode:
     {% set L = printer["gcode_macro _Probe_Variables"].probe_lock %}
     {% set V = printer["gcode_macro _User_Variables"].verbose %}
     # Get Docking location
+    {% set Ro = printer["gcode_macro _User_Variables"].rotated_probe %}
     {% set Mx = printer["gcode_macro _User_Variables"].dockmove_x|default(0) %}
     {% set My = printer["gcode_macro _User_Variables"].dockmove_y|default(0) %}
     {% set Mz = printer["gcode_macro _User_Variables"].dockmove_z|default(0) %}
@@ -295,11 +300,19 @@ gcode:
 
     #if there is no undock movement, assume older behavior
     {% if Mx == My == Mz == 0 %}
-        {% set Mx = 40 %}
+        {% if Ro %}
+            {% set My = -40 %}
+        {% else %}
+            {% set Mx = 40 %}
+        {% endif %}
     {% endif %}
     #if there is no Attach movement, assume older behavior
     {% if Ax == Ay == Az == 0 %}
-        {% set Ay = Da %}
+        {% if Ro %}
+            {% set Ax = -Da %}
+        {% else %}
+            {% set Ay = Da %}
+        {% endif %}
     {% endif %}
 
     _entry_point function=Dock_Probe
@@ -754,5 +767,22 @@ gcode:
           endfor %}
 
     Dock_Probe
-    
-   
+
+[gcode_macro Z_TILT_ADJUST]
+rename_existing:            _Z_TILT_ADJUST
+description: Perform Z tilt adjust with klicky automount
+gcode:
+
+    {% set V = printer["gcode_macro _User_Variables"].verbose %}
+    {% if V %}
+        { action_respond_info("Z Tilt Adjust") }
+    {% endif %}
+
+    _CheckProbe action=query
+    Attach_Probe
+
+    _Z_TILT_ADJUST {% for p in params
+           %}{'%s=%s ' % (p, params[p])}{%
+          endfor %}
+
+    Dock_Probe


### PR DESCRIPTION
**Added Variable_rotated_probe:**
- Boolean variable toggle for printers that have their probe 'facing' X+ instead of 'facing' Y-
- When True, default attaching will end in a -X move instead of a +Y move, default docking a -Y move instead of a +X move, etc.
- Only applies when dockmove variables and/or attachmove variables are uninitialized or 0

**Added Z_TILT_ADJUST macro override with klicky automount**
- Just copied the BED_MESH_CALIBRATE macro and changed where appropriate