### PR TITLE
Added ability to restore position with the _exit_point

### DIFF
--- a/Klipper_macro/klicky-probe.cfg
+++ b/Klipper_macro/klicky-probe.cfg
@@ -86,9 +86,10 @@ gcode:
 gcode:
     {% set function  = 'pre_' ~ params.FUNCTION  %}
     {% set move  = params.MOVE|default(0)  %}
+    {% set speed  = params.MOVE_SPEED|default(0) %}
     # mandatory to save the new safe position
     M400
-    RESTORE_GCODE_STATE NAME={function} MOVE={move}
+    RESTORE_GCODE_STATE NAME={function} MOVE={move} MOVE_SPEED={speed}
 
 
 [gcode_macro _entry_point]
@@ -380,11 +381,10 @@ gcode:
         { action_raise_error("Must Home X, Y and Z Axis First!") }
     {% endif %}
 
-    _entry_point function=PROBE_CALIBRATE
-
     # Go to Z safe distance before saving location in order to
     # avoid crashing the probe on the bed when coming back
     {% if (printer.toolhead.position.z < Hzh) %}
+        G90
         G0 Z{Hzh} F{Sz}
     {% endif %}
 
@@ -392,26 +392,24 @@ gcode:
     {% if (printer['gcode_move'].position.y > (My - Oy)) or (printer['gcode_move'].position.x > (Mx - Ox)) or (printer['gcode_move'].position.x < Ox) %}
       { action_raise_error("Must perform PROBE_CALIBRATE with the probe above the BED!!!") }
     {% endif%}
-    M400 # mandatory to save the new safe position
-    SAVE_GCODE_STATE NAME=_original_nozzle_location
+    
+    _entry_point function=PROBE_CALIBRATE
 
     _CheckProbe action=query
     Attach_Probe
 
     # Restore nozzle location to probe the right place
-    RESTORE_GCODE_STATE NAME=_original_nozzle_location MOVE=1 MOVE_SPEED={St}
+    _exit_point function=PROBE_CALIBRATE MOVE=1 MOVE_SPEED={St}
 
     _PROBE_CALIBRATE {% for p in params
             %}{'%s=%s ' % (p, params[p])}{%
            endfor %}
 
-        #store current nozzle location
-        SAVE_GCODE_STATE NAME=_original_nozzle_location
     Dock_Probe
 
     # Restore nozzle location again at the end
-    RESTORE_GCODE_STATE NAME=_original_nozzle_location MOVE=1 MOVE_SPEED={St}
-        _exit_point function=PROBE_CALIBRATE
+    _exit_point function=PROBE_CALIBRATE MOVE=1 MOVE_SPEED={St}
+
 
 # Probe Accuracy
 [gcode_macro PROBE_ACCURACY]
@@ -428,11 +426,10 @@ gcode:
         { action_raise_error("Must Home X, Y and Z Axis First!") }
     {% endif %}
 
-    _entry_point function=PROBE_ACCURACY
-
     # Go to Z safe distance before saving location in order to
     # avoid crashing the probe on the bed when coming back
     {% if (printer.toolhead.position.z < Hzh) %}
+        G90
         G0 Z{Hzh} F{Sz}
     {% endif %}
 
@@ -440,27 +437,24 @@ gcode:
     {% if (printer.toolhead.position.y > (By - Oy)) %}
       { action_raise_error("Must perform PROBE_ACCURACY with the probe above the BED!!!") }
     {% endif%}
-    M400 # mandatory to save the new safe position
-    SAVE_GCODE_STATE NAME=_original_nozzle_location
+
+    _entry_point function=PROBE_ACCURACY
 
     _CheckProbe action=query
     Attach_Probe
 
     # Restore nozzle location to probe the right place
-    RESTORE_GCODE_STATE NAME=_original_nozzle_location MOVE=1 MOVE_SPEED={St}
+    _exit_point function=PROBE_ACCURACY MOVE=1 MOVE_SPEED={St}
 
     _PROBE_ACCURACY {% for p in params
             %}{'%s=%s ' % (p, params[p])}{%
            endfor %}
 
-        #store current nozzle location
-        SAVE_GCODE_STATE NAME=_original_nozzle_location
-
-        Dock_Probe
+    Dock_Probe
 
     # Restore nozzle location again at the end
-    RESTORE_GCODE_STATE NAME=_original_nozzle_location MOVE=1 MOVE_SPEED={St}
-        _exit_point function=PROBE_ACCURACY
+    _exit_point function=PROBE_ACCURACY MOVE=1 MOVE_SPEED={St}
+
 
 # enable to SET_KINEMATIC_POSITION for Z hop
 [force_move]


### PR DESCRIPTION
Hey, here is mainly an aesthetic PR to simplify some macros.

First I added the option to restore the nozzle position using the _exit_point macro at a set speed.
Secondly, this also enable us to simplify the PROBE_ACCURACY and PROBE_CALIBRATE custom overrides by removing/replacing the multiples SAVE_GCODE_STATE and RESTORE_GCODE_STATE calls.