### PR TITLE
_CheckProbe does not properly forward ACTION parameter

### DIFF
--- a/Klipper_macro/klicky-probe.cfg
+++ b/Klipper_macro/klicky-probe.cfg
@@ -676,7 +676,7 @@ gcode:
 variable_probe_state: 0
 gcode:
     Query_Probe
-    _SetProbeState action={ ACTION }
+    _SetProbeState action={ params.ACTION }
 
 # Due to how templates are evaluated, we have query endstops in one
 # macro and call another macro to make decisions based on the result


### PR DESCRIPTION
I noticed that attach and dock failures weren't being detected, and I traced the issue back to `_CheckProbe`. It refers to `ACTION` as opposed to `params.ACTION` when calling `_SetProbeState`, which apparently doesn't work. `_SetProbeState` is currently always using the default value for the action, which is an empty string.

I'm using a recent copy of Klipper and Bullseye for RPi, so this may have been something that used to work but no longer does.