### PR TITLE
Params cleanup for Trident and v1.8

### DIFF
--- a/Klipper_macro/klicky-probe-for_Trident.cfg
+++ b/Klipper_macro/klicky-probe-for_Trident.cfg
@@ -676,7 +676,7 @@ gcode:
 variable_probe_state: 0
 gcode:
     Query_Probe
-    _SetProbeState action={ ACTION }
+    _SetProbeState action={ params.ACTION }
 
 # Due to how templates are evaluated, we have query endstops in one
 # macro and call another macro to make decisions based on the result

--- a/Klipper_macro/klicky-probe-for_v1.8.cfg
+++ b/Klipper_macro/klicky-probe-for_v1.8.cfg
@@ -676,7 +676,7 @@ gcode:
 variable_probe_state: 0
 gcode:
     Query_Probe
-    _SetProbeState action={ ACTION }
+    _SetProbeState action={ params.ACTION }
 
 # Due to how templates are evaluated, we have query endstops in one
 # macro and call another macro to make decisions based on the result


### PR DESCRIPTION
Sorry, my mistake, this is actually #35 again, to qualify `{ ACTION }` as `{ params.ACTION }`. I was a bit uncertain what was going on and didn't propagate this change to Trident and v1.8 in the original PR. This PR fixes that.

This is indeed necessitated by a Klipper change: see the change notes for 2021-11-02 [here](https://github.com/Klipper3d/klipper/blob/master/docs/Config_Changes.md). Parameter access without `params` was deprecated in May and support has now been removed.

I read through the rest of the code, and I believe this was the only access without the `params` prefix.