### PR TITLE
Added PROBE_LOCK parameter to G28 and Stealthburner LEDs support

### DIFF
--- a/Klipper_macro/klicky-probe.cfg
+++ b/Klipper_macro/klicky-probe.cfg
@@ -505,7 +505,7 @@ gcode:
     _CheckProbe action=query
 
     # reset parameters
-    {% set home_x, home_y, home_z = False, False, False %}
+    {% set home_x, home_y, home_z, leave_probe_attached = False, False, False, False %}
 
     # which axes have been requested for homing
     {% if not 'X' in params
@@ -536,6 +536,13 @@ gcode:
             _Homing_Variables reset=1
          {% endif %}
 
+    {% endif %}
+
+    {% if 'PROBE_LOCK' in params%}
+      {% if verbose %}
+        { action_respond_info("PROBE_LOCK = True") }
+      {% endif %}
+      {% set leave_probe_attached = True %}
     {% endif %}
 
     _entry_point function=homing_override
@@ -601,7 +608,12 @@ gcode:
 
         # if probe is configured as endstop, attach it, else dock the probe if attached
         {% if printer['configfile'].config["stepper_z"]["endstop_pin"] == 'probe:z_virtual_endstop' %}
+          # if PROBE_LOCK parameter is given, Attach Probe and lock until it´s unlocked
+          {% if leave_probe_attached %}
+            Attach_Probe_Lock
+          {% else %}
             Attach_Probe
+          {% endif %}
         {% else %}
             Dock_Probe
         {% endif %}

--- a/Klipper_macro/klicky-probe_for_Stealthburner.cfg
+++ b/Klipper_macro/klicky-probe_for_Stealthburner.cfg
@@ -1,0 +1,847 @@
+# This macro was provided by discord user Garrettwp to whom i give my thanks for sharing it with me.
+# I have tweaked it a lot.
+#
+# this macro is  based on the great Annex magprobe dockable probe macros "#Originally developed by Mental, modified for better use on K-series printers by RyanG and Trails"
+# that macro can be found here https://github.com/Annex-Engineering/Annex-Engineering_Other_Printer_Mods/blob/master/All_Printers/Microswitch_Probe/Klipper_Macros/dockable_probe_macros.cfg
+#
+# by standing on the shoulders of giants, lets see if we can see further
+# User richardjm revised the macro variables and added some functions, thanks a lot
+
+[gcode_macro _User_Variables]
+variable_stealthburner:         True  # Enable Stealthburner status LEDs
+variable_verbose:               True  # Enable verbose output
+variable_travel_speed:          200   # how fast all other travel moves will be performed when running these macros
+variable_dock_speed:            50    # how fast should the toolhead move when docking the probe for the final movement
+variable_release_speed:         75    # how fast should the toolhead move to release the hold of the magnets after docking
+variable_z_drop_speed:          20    # how fast the z will lower when moving to the z location to clear the probe
+
+variable_safe_z:         	    10    # Minimum Z for attach/dock and homing functions
+# if true it will move the bed away from the nozzle when Z is not homed
+variable_enable_z_hop:          False # set this to false for beds that fall significantly under gravity (almost to Z max)
+
+variable_max_bed_y:             250   # maximum Bed size avoids doing a probe_accuracy outside the bed
+variable_max_bed_x:             250   # maximum Bed size avoids doing a probe_accuracy outside the bed
+
+# if a separate Z endstop switch is in
+# use, specify the coordinates of the switch here (Voron).
+# Set to 0 to have the probe move to center of bed
+variable_z_endstop_x:            0 # default 1000
+variable_z_endstop_y:            0 # default 1000
+
+#dock location 
+variable_docklocation_x:        -1  # X Dock position
+variable_docklocation_y:        256  # Y Dock position
+variable_docklocation_z:        -128  # Z dock position (-128 for a gantry mount)
+
+#Dock move (on a V2, there should be no need to adjust these values)
+Variable_dockmove_x:                40    # Final toolhead movement to release
+Variable_dockmove_y:                0     # the probe on the dock
+Variable_dockmove_z:                0     # (can be negative)
+
+#Attach move (on a V2, there should be no need to adjust these values)
+Variable_attachmove_x:              0     # Final toolhead movement to Dock
+Variable_attachmove_y:              30    # the probe on the dock
+Variable_attachmove_z:              0     # (can be negative)
+
+#Umbilical to help untangle the umbilical in difficult situations
+variable_umbilical:             False # should we untabgle the umbilical
+variable_umbilical_x:           15    # X umbilical position
+variable_umbilical_y:           15    # Y umbilical position
+
+# location to park the toolhead
+variable_park_toolhead:         False  # Enable toolhead parking
+variable_parkposition_x:        75
+variable_parkposition_y:        75
+variable_parkposition_z:        30
+
+variable_version:               1     # Helps users to update the necessary variables, do not update if the variables above are not updated
+
+# Do not modify below
+gcode:
+    {% set Mx = printer['configfile'].config["stepper_x"]["position_max"]|float %}
+    {% set My = printer['configfile'].config["stepper_y"]["position_max"]|float %}
+    {% set Ox = printer['configfile'].config["probe"]["x_offset"]|float %}
+    {% set Oy = printer['configfile'].config["probe"]["y_offset"]|float %}
+    {% set Oz = printer['configfile'].config["probe"]["z_offset"]|float %}
+
+    # if docklocation_z is zero, use Home Z height for safety
+    {% if docklocation_z == 0 %}
+        SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=docklocation_z VALUE={ home_z_height }
+    {% endif %}
+
+    # If x, y coordinates are set for z endstop, assign them
+    {% if z_endstop_x != 0 or z_endstop_y != 0 %}
+        SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=z_endstop_x VALUE={ z_endstop_x }
+        SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=z_endstop_y VALUE={ z_endstop_y }
+
+    # if no x, y coordinates for z endstop, assume probe is endstop and move toolhead to center of bed
+    {% else %}
+        SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=z_endstop_x VALUE={ (Mx * 0.5) - Ox }
+        SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=z_endstop_y VALUE={ (My * 0.5) - Oy }
+    {% endif %}
+
+[gcode_macro _Probe_Variables]
+variable_probe_attached:            False
+variable_probe_state:               False
+variable_probe_lock:                False
+variable_z_endstop_x:               0
+variable_z_endstop_y:               0
+gcode:
+
+
+#checks if the variable definitions are up to date
+[gcode_macro _klicky_check_variables_version]
+gcode:
+    {% set version = printer["gcode_macro _User_Variables"].version|default(0) %}
+
+    {% if version != 1 %}
+        _RAISE_ERROR MESSAGE="Please update your klicky variables, there are some functionality changes"
+	{% endif %}
+
+[gcode_macro _exit_point]
+gcode:
+    {% set function  = 'pre_' ~ params.FUNCTION %}
+    {% set move  = params.MOVE|default(0) %}
+    # mandatory to save the new safe position
+    M400
+    RESTORE_GCODE_STATE NAME={function} MOVE={move}
+
+
+[gcode_macro _entry_point]
+gcode:
+    {% set function  = 'pre_' ~ params.FUNCTION %}
+    # mandatory to save the new safe position
+    M400
+    SAVE_GCODE_STATE NAME={function}
+    # removes the Z offset for better bed based docking
+    SET_GCODE_OFFSET Z=0
+    # all the macros initially assume absolute positioning
+    G90
+
+[gcode_macro _Homing_Variables]
+gcode:
+    {% set reset  = params.RESET|default(0) %}
+    {% if reset %}
+        SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=probe_lock VALUE={ False }
+    {% endif %}
+
+##########################
+# Attach probe and lock it
+[gcode_macro Attach_Probe_Lock]
+description: Attaches Klicky Probe, can only be docked after unlocking
+gcode:
+    Attach_Probe
+    _Probe_Lock
+
+########################
+# Dock probe and lock it
+[gcode_macro Dock_Probe_Unlock]
+description: Docks Klicky Probe even if it was locked
+gcode:
+    _Probe_Unlock
+    Dock_Probe
+
+##############
+# Unlock Probe
+[gcode_macro _Probe_Unlock]
+description: Unlocks Klicky Probe state
+gcode:
+    SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=probe_lock VALUE={ False }
+
+############
+# Lock Probe
+[gcode_macro _Probe_Lock]
+description: Locks Klicky Probe state
+gcode:
+    SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=probe_lock VALUE={ True }
+
+######################
+# Attach Probe Routine
+[gcode_macro Attach_Probe]
+description: Attaches Klicky Probe
+gcode:
+	# See if the position should be restored after the attach
+    {% set goback  = params.BACK|default(0) %}
+    # Get probe attach status
+    {% set probe_attached = printer["gcode_macro _Probe_Variables"].probe_attached %}
+    {% set probe_lock = printer["gcode_macro _Probe_Variables"].probe_lock %}
+    {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
+    # Get Docking location
+    {% set dockmove_x = printer["gcode_macro _User_Variables"].dockmove_x|default(0) %}
+    {% set dockmove_y = printer["gcode_macro _User_Variables"].dockmove_y|default(0) %}
+    {% set dockmove_z = printer["gcode_macro _User_Variables"].dockmove_z|default(0) %}
+    {% set docklocation_x = printer["gcode_macro _User_Variables"].docklocation_x %}
+    {% set docklocation_y = printer["gcode_macro _User_Variables"].docklocation_y %}
+    {% set docklocation_z = printer["gcode_macro _User_Variables"].docklocation_z %}
+    {% set attachmove_x = printer["gcode_macro _User_Variables"].attachmove_x|default(0) %}
+    {% set attachmove_y = printer["gcode_macro _User_Variables"].attachmove_y|default(0) %}
+    {% set attachmove_z = printer["gcode_macro _User_Variables"].attachmove_z|default(0) %}
+    # Safe Z for travel
+	{% set safe_z = printer["gcode_macro _User_Variables"].safe_z %}
+	{% set enable_z_hop = printer["gcode_macro _User_Variables"].enable_z_hop %}
+    # Set feedrates
+    {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
+    {% set dock_feedrate = printer["gcode_macro _User_Variables"].dock_speed * 60 %}
+    {% set release_feedrate = printer["gcode_macro _User_Variables"].release_speed * 60 %}
+    {% set z_drop_feedrate = printer["gcode_macro _User_Variables"].z_drop_speed * 60 %}
+
+    _entry_point function=Attach_Probe
+
+    # If there is no undock movement, fail
+    {% if dockmove_x == dockmove_y == dockmove_z == 0 %}
+        _RAISE_ERROR MESSAGE="No dockmove location!! To restore old behavior place 40 in dockmove_x"
+    {% endif %}
+    # If there is no Attach movement, fail
+    {% if attachmove_x == attachmove_y == attachmove_z == 0 %}
+        _RAISE_ERROR MESSAGE="No attachmove location!!  To restore old behavior place dockarmslenght value in dockmove_x"
+    {% endif %}
+
+    # If x and y are not homed
+    {% if not 'xy' in printer.toolhead.homed_axes %}
+        _RAISE_ERROR MESSAGE="Must Home X and Y Axis First!"
+
+    # If probe not attached and locked
+    {% elif not probe_attached and not probe_lock %}
+        {% if verbose %}
+            { action_respond_info("Attaching Probe") }
+        {% endif %}
+
+        {% if not 'z' in printer.toolhead.homed_axes %}
+            {% if verbose %}
+                { action_respond_info("Resetting Z position to zero") }
+            {% endif %}
+            SET_KINEMATIC_POSITION Z=0
+            {% if not enable_z_hop %} # Disables safe_z
+                {% set safe_z = 0 %}
+            {% endif %}
+        {% endif %}
+
+        # Prior to saving actual position, check if its necessary to move to a safe Z
+        # that has enought overhead for the attached probe
+        {% if printer.toolhead.position.z < safe_z %}
+            {% if verbose %}
+                { action_respond_info("moving to a safe Z distance") }
+            {% endif %}
+            G0 Z{safe_z} F{z_drop_feedrate}
+        {% endif %}
+
+        {% if not 'z' in printer.toolhead.homed_axes %}
+            {% if verbose %}
+                { action_respond_info("Resetting Z position to zero") }
+            {% endif %}
+            SET_KINEMATIC_POSITION Z=0
+        {% endif %}
+
+        {% if printer.toolhead.position.z < safe_z %}
+            G0 Z{safe_z} F{z_drop_feedrate}
+        {% endif %}
+
+        _Umbilical_Path
+
+		_entry_point function=Attach_Probe_intern
+
+
+        # Probe entry location
+        G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}
+        {% if docklocation_z != -128 %}
+            G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}
+        {% endif %}
+
+        # Drop Probe to Probe location
+        {% if docklocation_z != -128 %}
+            G0 Z{docklocation_z} F{dock_feedrate}
+        {% endif %}
+        G0 X{docklocation_x} Y{docklocation_y} F{dock_feedrate}
+
+        # Probe Attach
+        {% if docklocation_z != -128 %}
+        G0 Z{docklocation_z|int - attachmove_z|int} F{z_drop_feedrate}
+        {% endif %}
+        G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{release_feedrate}
+
+        # Go to Z safe distance
+        {% if printer.toolhead.position.z < safe_z %}
+          G0 Z{safe_z} F{z_drop_feedrate}
+        {% endif %}
+
+        _Park_Toolhead
+
+        _CheckProbe action=attach
+
+		_exit_point function=Attach_Probe_intern move={goback}
+
+    {% elif probe_lock %}
+        {% if verbose %}
+            { action_respond_info("Probe locked!") }
+        {% endif %}
+
+        # Probe attached, do nothing
+        _CheckProbe action=query
+
+    {% else %}
+        {% if verbose %}
+            { action_respond_info("Probe already attached!") }
+        {% endif %}
+
+        # Probe attached, do nothing
+        _CheckProbe action=query
+
+    {% endif %}
+
+    _exit_point function=Attach_Probe move={goback}
+
+####################
+# Dock Probe Routine
+[gcode_macro Dock_Probe]
+description: Docks Klicky Probe
+gcode:
+	# See if the position should be restored after the dock
+    {% set goback  = params.back|default(0) %}
+    # Get probe attach status
+    {% set probe_attached = printer["gcode_macro _Probe_Variables"].probe_attached %}
+    {% set probe_lock = printer["gcode_macro _Probe_Variables"].probe_lock %}
+    {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
+    # Get Docking location
+    {% set dockmove_x = printer["gcode_macro _User_Variables"].dockmove_x|default(0) %}
+    {% set dockmove_y = printer["gcode_macro _User_Variables"].dockmove_y|default(0) %}
+    {% set dockmove_z = printer["gcode_macro _User_Variables"].dockmove_z|default(0) %}
+    {% set docklocation_x = printer["gcode_macro _User_Variables"].docklocation_x %}
+    {% set docklocation_y = printer["gcode_macro _User_Variables"].docklocation_y %}
+    {% set docklocation_z = printer["gcode_macro _User_Variables"].docklocation_z %}
+    {% set attachmove_x = printer["gcode_macro _User_Variables"].attachmove_x|default(0) %}
+    {% set attachmove_y = printer["gcode_macro _User_Variables"].attachmove_y|default(0) %}
+    {% set attachmove_z = printer["gcode_macro _User_Variables"].attachmove_z|default(0) %}
+    # Safe Z for travel
+    {% set safe_z = printer["gcode_macro _User_Variables"].safe_z|float %}
+    # Set feedrates
+    {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
+    {% set dock_feedrate = printer["gcode_macro _User_Variables"].dock_speed * 60 %}
+    {% set release_feedrate = printer["gcode_macro _User_Variables"].release_speed * 60 %}
+    {% set z_drop_feedrate = printer["gcode_macro _User_Variables"].z_drop_speed * 60 %}
+
+    # If there is no undock movement, fail
+    {% if dockmove_x == dockmove_y == dockmove_z == 0 %}
+        _RAISE_ERROR MESSAGE="No dockmove location!! To restore old behavior place 40 in dockmove_x"
+    {% endif %}
+    # If there is no Attach movement, fail
+    {% if attachmove_x == attachmove_y == attachmove_z == 0 %}
+        _RAISE_ERROR MESSAGE="No attachmove location!!  To restore old behavior place dockarmslenght value in dockmove_x"
+    {% endif %}
+
+    # If axis aren't homed, fail
+    {% if not 'xyz' in printer.toolhead.homed_axes %}
+        _RAISE_ERROR MESSAGE="Must Home X, Y and Z Axis First!"
+    {% endif %}
+
+    _entry_point function=Dock_Probe
+
+    # If probe not attached and not locked
+    {% if probe_attached and not probe_lock %}
+        {% if verbose %}
+            { action_respond_info("Docking Probe") }
+        {% endif %}
+
+        {% if printer.toolhead.position.z < safe_z %}
+            G0 Z{safe_z} F{z_drop_feedrate}
+        {% endif %}
+
+        _Umbilical_Path
+
+        # Probe entry location
+        G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}
+        {% if docklocation_z != -128 %}
+            G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}
+        {% endif %}
+
+        # Drop Probe to Probe location
+        G0 X{docklocation_x} Y{docklocation_y} F{dock_feedrate}
+        {% if docklocation_z != -128 %}
+            G0 Z{docklocation_z} F{dock_feedrate}
+        {% endif %}
+
+        # Probe decoupling
+        {% if docklocation_z != -128 %}
+            G0 Z{docklocation_z|int + dockmove_z|int} F{release_feedrate}
+        {% endif %}
+        G0 X{docklocation_x|int + dockmove_x|int} Y{docklocation_y|int + dockmove_y|int} F{release_feedrate}
+
+        # Go to Z safe distance
+        {% if printer.toolhead.position.z < safe_z %}
+          G0 Z{safe_z} F{z_drop_feedrate}
+        {% endif %}
+
+        _Park_Toolhead
+
+        G4 P1000
+        _CheckProbe action=dock
+
+	{% elif probe_lock %}
+		{% if verbose %}
+			{ action_respond_info("Probe locked") }
+		{% endif %}
+
+		# Probe docked, do nothing
+		_CheckProbe action=query
+
+    {% else %}
+        {% if verbose %}
+            { action_respond_info("Probe already docked") }
+        {% endif %}
+
+        # Probe docked, do nothing
+        _CheckProbe action=query
+
+    {% endif %}
+
+    _exit_point function=Dock_Probe move={goback}
+
+#################
+# Probe Calibrate
+[gcode_macro PROBE_CALIBRATE]
+rename_existing: _PROBE_CALIBRATE
+description:Calibrate the probes z_offset with klicky automount
+gcode:
+    {% set stealthburner = printer["gcode_macro _User_Variables"].stealthburner %}
+    {% set safe_z = printer["gcode_macro _User_Variables"].safe_z|float %}
+    {% set z_drop_feedrate = printer["gcode_macro _User_Variables"].z_drop_speed * 60 %}
+    {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed %}
+    {% set max_x = printer["gcode_macro _User_Variables"].max_bed_x %}
+    {% set max_y = printer["gcode_macro _User_Variables"].max_bed_y %}
+    {% set probe_offset_x = printer['configfile'].config["probe"]["x_offset"]|float %}
+    {% set probe_offset_y = printer['configfile'].config["probe"]["y_offset"]|float %}
+
+    {% if not 'xyz' in printer.toolhead.homed_axes %}
+        _RAISE_ERROR MESSAGE="Must Home X, Y and Z Axis First!"
+    {% endif %}
+
+    # Protect against PROBE CALIBRATE performed from outside the bed
+    {% if printer['gcode_move'].position.y > (max_y - probe_offset_y)
+		  or printer['gcode_move'].position.y < probe_offset_y
+          or printer['gcode_move'].position.x > (max_x - probe_offset_x)
+          or printer['gcode_move'].position.x < probe_offset_x %}
+      _RAISE_ERROR MESSAGE="Must perform PROBE_CALIBRATE with the probe above the BED!"
+    {% endif%}
+
+    _entry_point function=PROBE_CALIBRATE
+
+    _CheckProbe action=query
+    Attach_Probe back=1
+
+    {% if stealthburner %}
+      STATUS_BUSY
+    {% endif %}
+
+    _PROBE_CALIBRATE {% for p in params
+            %}{'%s=%s ' % (p, params[p])}{%
+           endfor %}
+
+    Dock_Probe back=1
+
+    _exit_point function=PROBE_CALIBRATE move=1
+
+################
+# Probe Accuracy
+[gcode_macro PROBE_ACCURACY]
+rename_existing: _PROBE_ACCURACY
+description:Probe Z-height accuracy at current XY position with klicky automount
+gcode:
+    {% set stealthburner = printer["gcode_macro _User_Variables"].stealthburner %}
+    {% set safe_z = printer["gcode_macro _User_Variables"].safe_z|float %}
+    {% set z_drop_feedrate = printer["gcode_macro _User_Variables"].z_drop_speed * 60 %}
+    {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed %}
+    {% set max_x = printer["gcode_macro _User_Variables"].max_bed_x %}
+    {% set max_y = printer["gcode_macro _User_Variables"].max_bed_y %}
+    {% set probe_offset_x = printer['configfile'].config["probe"]["x_offset"]|float %}
+    {% set probe_offset_y = printer['configfile'].config["probe"]["y_offset"]|float %}
+
+    {% if not 'xyz' in printer.toolhead.homed_axes %}
+        _RAISE_ERROR MESSAGE="Must Home X, Y and Z Axis First!"
+    {% endif %}
+    
+    _entry_point function=PROBE_ACCURACY
+
+    # Protect against PROBE_ACCURACY performed from outside the bed
+    {% if printer['gcode_move'].position.y > (max_y - probe_offset_y)
+		  or printer['gcode_move'].position.y < probe_offset_y
+          or printer['gcode_move'].position.x > (max_x - probe_offset_x)
+          or printer['gcode_move'].position.x < probe_offset_x %}
+      _RAISE_ERROR MESSAGE="Must perform PROBE_ACCURACY with the probe above the BED!"
+    {% endif%}
+
+    _CheckProbe action=query
+    Attach_Probe back=1
+
+    {% if stealthburner %}
+      STATUS_BUSY
+    {% endif %}
+
+    _PROBE_ACCURACY {% for p in params
+            %}{'%s=%s ' % (p, params[p])}{%
+           endfor %}
+
+    Dock_Probe back=1										   
+
+    _exit_point function=PROBE_ACCURACY move=1
+
+#############################################
+# Enable to SET_KINEMATIC_POSITION for Z hop
+[force_move]
+enable_force_move: True
+
+#################
+# Homing Override
+[homing_override]
+axes: xyz
+gcode:
+    # collect user state variables
+    _User_Variables
+    {% set stealthburner = printer["gcode_macro _User_Variables"].stealthburner %}
+    {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
+    {% set safe_z = printer["gcode_macro _User_Variables"].safe_z|float %}
+    # Safe Z for travel
+	{% set safe_z = printer["gcode_macro _User_Variables"].safe_z %}
+	{% set enable_z_hop = printer["gcode_macro _User_Variables"].enable_z_hop %}
+    {% set attachmove_x = printer["gcode_macro _User_Variables"].attachmove_x|default(0) %}
+    {% set attachmove_y = printer["gcode_macro _User_Variables"].attachmove_y|default(0) %}
+    {% set attachmove_z = printer["gcode_macro _User_Variables"].attachmove_z|default(0) %}
+    {% set z_drop_feedrate = printer["gcode_macro _User_Variables"].z_drop_speed * 60 %}
+    
+    #checks if the variable definitions are up to date
+    _klicky_check_variables_version
+
+    # if there is no Attach movement, fail
+    {% if attachmove_x == attachmove_y == attachmove_z == 0 %}
+        _RAISE_ERROR MESSAGE="No attachmove location!"
+    {% endif %}
+
+    _CheckProbe action=query
+
+    # reset parameters
+    #{% set home_x, home_y, home_z = False, False, False %}
+    {% set home_x, home_y, home_z, leave_probe_attached = False, False, False, False %}
+
+    # which axes have been requested for homing
+    {% if not 'X' in params
+        and not 'Y' in params
+        and not 'Z' in params %}
+
+        {% set home_x, home_y, home_z = True, True, True %}
+
+    {% else %}
+        # Frame mount x-endstop - home Y before X
+        {% if 'X' in params %}
+            {% set home_x = True %}
+        {% endif %}
+
+        {% if 'Y' in params %}
+            {% set home_y = True %}
+        {% endif %}
+
+        {% if 'Z' in params %}
+            {% set home_z = True %}
+        {% endif %}
+
+        {% if 'X' in params
+          and 'Y' in params
+          and 'Z' in params %}
+            # reset homing state variables
+            # if homing all axes
+            _Homing_Variables reset=1
+         {% endif %}
+
+    {% endif %}
+
+    {% if 'PROBE_LOCK' in params%}
+      {% if verbose %}
+        { action_respond_info("PROBE_LOCK = True") }
+      {% endif %}
+      {% set leave_probe_attached = True %}
+    {% endif %}
+
+    _entry_point function=homing_override
+    {% if stealthburner %}
+      STATUS_HOMING
+    {% endif %}
+    # if Z is not homed, do not move the bed if it goes down
+    {% if 'z' not in printer.toolhead.homed_axes %}
+            {% if not enable_z_hop %} # Disables safe_z
+                {% set safe_z = 0 %}
+            {% endif %}
+    {% endif %}
+
+    {% if home_z %}
+        {% if 'z' in printer.toolhead.homed_axes %}
+            {% if printer.toolhead.position.z < safe_z %}
+                {% if verbose %}
+                    { action_respond_info("Z too low, performing ZHOP") }
+                {% endif %}
+                G0 Z{safe_z} F{z_drop_feedrate}
+            {% endif %}
+        {% else %}
+            {% if verbose %}
+                { action_respond_info("Z not homed, forcing full G28") }
+            {% endif %}
+            SET_KINEMATIC_POSITION X=0 Y=0 Z=0
+            G0 Z{safe_z} F{z_drop_feedrate}
+            {% set home_x, home_y, home_z = True, True, True %}
+        {% endif %}
+    {% endif %}
+
+    # if the dock is oriented on the Y, first do Y endstop
+    {% if attachmove_y == 0 %}
+        # Home y
+        {% if home_y %}
+            {% if verbose %}
+                { action_respond_info("Homing Y") }
+            {% endif %}
+            G28 Y0
+        {% endif %}
+        {% set home_y = False %}
+    {% endif %}
+
+
+    # Home x
+    {% if home_x %}
+        {% if verbose %}
+            { action_respond_info("Homing X") }
+        {% endif %}
+        G28 X0
+    {% endif %}
+
+    # Home y
+    {% if home_y %}
+        {% if verbose %}
+            { action_respond_info("Homing Y") }
+        {% endif %}
+        G28 Y0
+    {% endif %}
+    # Home z
+    {% if home_z %}
+        {% if verbose %}
+            { action_respond_info("Homing Z") }
+        {% endif %}
+
+        # if probe is configured as endstop, attach it, else dock the probe if attached
+        {% if printer['configfile'].config["stepper_z"]["endstop_pin"] == 'probe:z_virtual_endstop' %}
+          # if PROBE_LOCK parameter is given, Attach Probe and lock until it´s unlocked
+          {% if leave_probe_attached %}
+            Attach_Probe_Lock
+          {% else %}
+            Attach_Probe
+          {% endif %}
+        {% else %}
+            Dock_Probe
+        {% endif %}
+
+        _Home_Z
+
+        # if probe is configured as endstop, dock it
+        {% if printer['configfile'].config["stepper_z"]["endstop_pin"] == 'probe:z_virtual_endstop' %}
+            Dock_Probe         
+        {% endif %}
+    {% endif %}
+    _CheckProbe action=query
+
+    # park the toolhead
+    _Park_Toolhead
+
+    _exit_point function=homing_override
+
+# Umbilical path setup
+[gcode_macro _Umbilical_Path]
+gcode:
+    {% set umbilical = printer["gcode_macro _User_Variables"].umbilical %}
+    {% set umbilical_x = printer["gcode_macro _User_Variables"].umbilical_x %}
+    {% set umbilical_y = printer["gcode_macro _User_Variables"].umbilical_y %}
+    {% set safe_z = printer["gcode_macro _User_Variables"].safe_z|float %}
+    {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
+
+    {% if umbilical %}
+        # Used to give the umbilical a better path to follow and coil properly if dock is tight in space
+        _entry_point function=Umbilical_Path
+
+        G0 X{umbilical_x} Y{umbilical_y} Z{safe_z} F{travel_feedrate}
+
+        _exit_point function=Umbilical_Path
+    {% endif %}
+
+# Home Z Routine
+[gcode_macro _Home_Z]
+gcode:
+    {% set z_endstop_x = printer["gcode_macro _Probe_Variables"].z_endstop_x %}
+    {% set z_endstop_y = printer["gcode_macro _Probe_Variables"].z_endstop_y %}
+    {% set safe_z = printer["gcode_macro _User_Variables"].safe_z|float %}
+    {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
+    {% set z_drop_feedrate = printer["gcode_macro _User_Variables"].z_drop_speed * 60 %}
+    {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
+
+    _entry_point function=Home_Z
+
+    # if x and y are not homed yet, raise error
+    {% if not 'xy' in printer.toolhead.homed_axes %}
+        _RAISE_ERROR MESSAGE="Must Home X and Y Axis First!"
+    {% else %}
+        {% if not 'z' in printer.toolhead.homed_axes %}
+            {% if verbose %}
+                { action_respond_info("Resetting Z position to zero") }
+            {% endif %}
+            SET_KINEMATIC_POSITION Z=0
+        {% endif %}
+
+        # Move tool to safe homing position and home Z axis
+        # location of z endstop
+        G0 X{z_endstop_x} Y{z_endstop_y} F{travel_feedrate}
+        G28 Z0
+        G0 Z{safe_z} F{z_drop_feedrate}
+    {% endif %}
+
+    _exit_point function=Home_Z
+
+# Check to see if probe is where it is supposed to be after
+# attaching/docking maneuver and set homing error or shutdown
+[gcode_macro _CheckProbe]
+variable_probe_state: 0
+gcode:
+    Query_Probe
+    _SetProbeState action={ params.ACTION }
+
+# Due to how templates are evaluated, we have query endstops in one
+# macro and call another macro to make decisions based on the result
+[gcode_macro _SetProbeState]
+gcode:
+    {% set query_probe_triggered = printer.probe.last_query %}
+    {% set action  = params.ACTION|default('') %}
+
+    # If triggered (true), probe not attached
+    {% if query_probe_triggered %}
+        SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=probe_attached VALUE={ False }
+        STATUS_PROBE_DOCKED
+    {% else %}
+        # If not triggered (false), probe attached
+        SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=probe_attached VALUE={ True }
+        STATUS_PROBE_ATTACHED
+    {% endif %}
+
+    {% if action == 'query' %}
+          SET_GCODE_VARIABLE MACRO=_Probe_Variables VARIABLE=probe_state VALUE={ query_probe_triggered }
+    {% endif %}
+
+    # If probe fails to attach/detach
+
+    # If not docked
+    {% if not query_probe_triggered and action == 'dock' %}
+        _RAISE_ERROR MESSAGE="Probe dock failed!"
+    {% endif %}
+
+    # If not attached
+    {% if query_probe_triggered and action == 'attach' %}
+        _RAISE_ERROR MESSAGE="Probe attach failed!"
+    {% endif %}
+
+[gcode_macro _RAISE_ERROR]
+gcode:
+    {% set stealthburner = printer["gcode_macro _User_Variables"].stealthburner %}
+    {% if stealthburner %}
+      STATUS_ERROR
+    {% endif %}
+    _ACTION_RAISE_ERROR {% for p in params
+          %}{'%s=%s ' % (p, params[p])}{%
+         endfor %}
+
+[gcode_macro _ACTION_RAISE_ERROR]
+gcode:
+    {% set message = params.MESSAGE|default("")|string %}
+    { action_raise_error(message) }
+
+# Park Toolhead Routine
+[gcode_macro _Park_Toolhead]
+gcode:
+    {% set park_toolhead = printer["gcode_macro _User_Variables"].park_toolhead %}
+    {% set parkposition_x = printer["gcode_macro _User_Variables"].parkposition_x %}
+    {% set parkposition_y = printer["gcode_macro _User_Variables"].parkposition_y %}
+    {% set parkposition_z = printer["gcode_macro _User_Variables"].parkposition_z %}
+    {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
+    {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
+
+    _entry_point function=Park_Toolhead
+
+    {% if stealthburner %}
+      STATUS_READY
+    {% endif %}
+
+    {% if park_toolhead and 'xyz' in printer.toolhead.homed_axes %}
+        {% if verbose %}
+            { action_respond_info("Parking Toolhead") }
+        {% endif %}
+        G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
+    {% endif %}
+    _exit_point function=Park_Toolhead
+ 
+# Z Tilt Adjust
+[gcode_macro Z_TILT_ADJUST]
+rename_existing:             _Z_TILT_ADJUST
+description:
+gcode:
+    {% set V = printer["gcode_macro _User_Variables"].verbose %}
+    {% if V %}
+        { action_respond_info("Z Tilt Adjust") }
+    {% endif %}
+
+    _CheckProbe action=query
+    Attach_Probe
+
+    {% if stealthburner %}
+      STATUS_CALIBRATING_Z
+    {% endif %}
+
+    _Z_TILT_ADJUST {% for p in params
+          %}{'%s=%s ' % (p, params[p])}{%
+         endfor %}
+    G28 Z0
+    Dock_Probe
+	
+[gcode_macro BED_MESH_CALIBRATE]
+rename_existing:             _BED_MESH_CALIBRATE
+description: Perform Mesh Bed Leveling with klicky automount
+gcode:
+
+    {% set V = printer["gcode_macro _User_Variables"].verbose %}
+    {% if V %}
+        { action_respond_info("Bed Mesh Calibrate") }
+    {% endif %}
+
+    _CheckProbe action=query
+    Attach_Probe
+
+    {% if stealthburner %}
+      STATUS_MESHING    
+    {% endif %}
+
+    _BED_MESH_CALIBRATE {% for p in params
+           %}{'%s=%s ' % (p, params[p])}{%
+          endfor %}
+
+    Dock_Probe
+
+## Screws Tilt Adjust
+#[gcode_macro SCREWS_TILT_CALCULATE]
+#rename_existing:             _SCREWS_TILT_CALCULATE
+#description: 
+#gcode:
+#    {% set V = printer["gcode_macro _User_Variables"].verbose %}
+#    {% if V %}
+#        { action_respond_info("Screws Tilt Adjust") }
+#    {% endif %}
+#
+#    _CheckProbe action=query
+#    Attach_Probe
+#
+#    {% if stealthburner %}
+#      STATUS_CALIBRATING_Z
+#    {% endif %}
+#
+#    _SCREWS_TILT_CALCULATE {% for p in params
+#          %}{'%s=%s ' % (p, params[p])}{%
+#         endfor %}
+#
+#    Dock_Probe


### PR DESCRIPTION
In order to reduce dock and attach movements during the print_start macro, i´ve added an additional PROBE_LOCK parameter to the [homing_override] section to lock the probe until it´s unlocked. Therefore it´s faster to do the z_tilt and bed_mesh_calibrate and the do the dock_probe_unlock macro at the end.