### PR TITLE
macros: use _HOME_X/_HOME_Y if they exist

### DIFF
--- a/Klipper_macros/README.md
+++ b/Klipper_macros/README.md
@@ -99,6 +99,12 @@ If however you would like to reduce the times that the toolhead attaches and doc
 
 When you don't need the probe attached anymore, run Dock_Probe_Unlock to dock and unlock the probe.
 
+## XY Sensorless homing 
+
+If you are using sensorless homing, and have your own X and/or Y homing macros, you can use override the klicky macros behavior with your very own _HOME_X and _HOME_Y macros.
+
+If they exist on your klipper configuration, klicky macro will use them instead of the default G28 commands.
+
 ## Advanced users
 
 **Beware going forward, you will leave the safety that the macros provide**

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -533,7 +533,11 @@ gcode:
         {% if verbose %}
             { action_respond_info("Homing X") }
         {% endif %}
-        G28 X0
+        {% if printer["gcode_macro _HOME_X"] is defined %}
+            _HOME_X
+        {% else %}
+            G28 X0
+        {% endif %}
     {% endif %}
 
     # Home y
@@ -541,7 +545,11 @@ gcode:
         {% if verbose %}
             { action_respond_info("Homing Y") }
         {% endif %}
-        G28 Y0
+        {% if printer["gcode_macro _HOME_Y"] is defined %}
+            _HOME_Y
+        {% else %}
+            G28 Y0
+        {% endif %}
     {% endif %}
     # Home z
     {% if home_z %}


### PR DESCRIPTION
This change is to make it easier for folks with sensorless homing setups to use Klicky without modifying the provided Klicky macros.