### PR TITLE
Add check for _HOME_Y to all instances of Y homing

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -553,7 +553,11 @@ gcode:
             {% if verbose %}
                 { action_respond_info("Homing Y") }
             {% endif %}
-            G28 Y0
+            {% if printer["gcode_macro _HOME_Y"] is defined %}
+                _HOME_Y
+            {% else %}
+                G28 Y0
+            {% endif %}
         {% endif %}
         {% set home_y = False %}
     {% endif %}


### PR DESCRIPTION
The early y_homing for y oriented docks was not using the _HOME_Y macro if defined.  Updated to make sure it will be called.

Issue referenced: #101 