### PR TITLE
allow probe accuracy to be closer to the bed minimum

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -418,6 +418,7 @@ gcode:
     {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed %}
     {% set max_x = printer["gcode_macro _User_Variables"].max_bed_x %}
     {% set max_y = printer["gcode_macro _User_Variables"].max_bed_y %}
+    {% set axis_min = printer['toolhead'].axis_minimum %}
     {% set probe_offset_x = printer['configfile'].config["probe"]["x_offset"]|float %}
     {% set probe_offset_y = printer['configfile'].config["probe"]["y_offset"]|float %}
 
@@ -429,9 +430,9 @@ gcode:
 
     # Protect against PROBE_ACCURACY performed from outside the bed
     {% if printer['gcode_move'].position.y > (max_y - probe_offset_y)
-          or printer['gcode_move'].position.y < probe_offset_y
+          or (printer['gcode_move'].position.y + probe_offset_y) < axis_min.y 
           or printer['gcode_move'].position.x > (max_x - probe_offset_x)
-          or printer['gcode_move'].position.x < probe_offset_x %}
+          or (printer['gcode_move'].position.x + probe_offset_x) < axis_min.x %}
       { action_raise_error("Must perform PROBE_ACCURACY with the probe above the BED!") }
     {% endif%}
 


### PR DESCRIPTION
Still can't perform probe accuracy above the bed near the minimum currently.

Example: 
bed min = 0, 0
probe offset = 0, 25

User won't be able to do probe accuracy at 5, 20, because position_y < offset_y, but in reality the probe is at 5, 45.

This edit will "permit" running probe accuracy down to y=-25, but that shouldn't be a problem because the toolhead will be asked to go beyond axis min and will get move out of range error. 
For users with the probe in front of toolhead (negative y offset), this will keep the probe within axis minimum.