### PR TITLE
feat(homing): allow separate x and y homing backoff

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -550,7 +550,8 @@ gcode:
     {% set attachmove_z = printer["gcode_macro _User_Variables"].attachmove_z|default(0) %}
     {% set z_drop_feedrate = printer["gcode_macro _User_Variables"].z_drop_speed * 60 %}
     {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
-    {% set home_backoff = printer["gcode_macro _User_Variables"].home_backoff|default(0) %}
+    {% set home_backoff_x = printer["gcode_macro _User_Variables"].home_backoff_x|default(0) %}
+    {% set home_backoff_y = printer["gcode_macro _User_Variables"].home_backoff_y|default(0) %}
     {% set override_homing = printer["gcode_macro _User_Variables"].override_homing|default('') %}
 
     #checks if the variable definitions are up to date
@@ -655,13 +656,13 @@ gcode:
                 _KlickyDebug msg="homing_override Homing Y G28 Y0"
                 G28 Y0
                 # does it need to back away from the home position
-                {% if home_backoff != 0 %}
+                {% if home_backoff_y != 0 %}
                     {% if (printer.configfile.settings.stepper_y.position_endstop > (printer.configfile.settings.stepper_y.position_min|default(0) + printer.configfile.settings.stepper_y.position_max)/2) %}
-                        _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop-home_backoff|int} F{travel_feedrate}"
-                        G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff|int} F{travel_feedrate}
+                        _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop-home_backoff_y|int} F{travel_feedrate}"
+                        G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff_y|int} F{travel_feedrate}
                     {% else %}
-                        _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff|int} F{travel_feedrate}"
-                        G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff|int} F{travel_feedrate}
+                        _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y|int} F{travel_feedrate}"
+                        G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y|int} F{travel_feedrate}
                     {%endif %}
                 {%endif %}
             {% endif %}
@@ -682,13 +683,13 @@ gcode:
             _KlickyDebug msg="homing_override Homing X G28 X0"
             G28 X0
             # does it need to back away from the home position
-            {% if home_backoff != 0 %}
+            {% if home_backoff_x != 0 %}
                 {% if (printer.configfile.settings.stepper_x.position_endstop > (printer.configfile.settings.stepper_x.position_min|default(0) + printer.configfile.settings.stepper_x.position_max)/2) %}
-                    _KlickyDebug msg="homing_override backing off X endstop, G0 X{printer.configfile.settings.stepper_x.position_endstop - home_backoff|int} F{travel_feedrate}"
-                    G0 X{printer.configfile.settings.stepper_x.position_endstop - home_backoff|int} F{travel_feedrate}
+                    _KlickyDebug msg="homing_override backing off X endstop, G0 X{printer.configfile.settings.stepper_x.position_endstop - home_backoff_x|int} F{travel_feedrate}"
+                    G0 X{printer.configfile.settings.stepper_x.position_endstop - home_backoff_x|int} F{travel_feedrate}
                 {% else %}
-                    _KlickyDebug msg="homing_override backing off X endstop, G0 X{printer.configfile.settings.stepper_x.position_endstop + home_backoff|int} F{travel_feedrate}"
-                    G0 X{printer.configfile.settings.stepper_x.position_endstop + home_backoff|int} F{travel_feedrate}
+                    _KlickyDebug msg="homing_override backing off X endstop, G0 X{printer.configfile.settings.stepper_x.position_endstop + home_backoff_x|int} F{travel_feedrate}"
+                    G0 X{printer.configfile.settings.stepper_x.position_endstop + home_backoff_x|int} F{travel_feedrate}
                 {%endif %}
             {%endif %}
         {% endif %}
@@ -705,13 +706,13 @@ gcode:
         {% else %}
             _KlickyDebug msg="homing_override Homing Y G28 Y0"
             G28 Y0
-            {% if home_backoff != 0 %}
+            {% if home_backoff_y != 0 %}
                 {% if (printer.configfile.settings.stepper_y.position_endstop > (printer.configfile.settings.stepper_y.position_min|default(0) + printer.configfile.settings.stepper_y.position_max)/2) %}
-                    _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff|int} F{travel_feedrate}"
-                    G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff|int} F{travel_feedrate}
+                    _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff_y|int} F{travel_feedrate}"
+                    G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff_y|int} F{travel_feedrate}
                 {% else %}
-                    _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff|int} F{travel_feedrate}"
-                    G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff|int} F{travel_feedrate}
+                    _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y|int} F{travel_feedrate}"
+                    G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y|int} F{travel_feedrate}
                 {%endif %}
             {%endif %}
         {% endif %}

--- a/Klipper_macros/klicky-variables.cfg
+++ b/Klipper_macros/klicky-variables.cfg
@@ -2,12 +2,12 @@
 # I have tweaked it a lot.
 # They are based on the great Annex magprobe dockable probe macros "#Originally developed by Mental,
 # modified for better use on K-series printers by RyanG and Trails", kudos to them.
-# That macro as since evolved into a klipper plugin that currently is pending inclusion in klipper, 
+# That macro as since evolved into a klipper plugin that currently is pending inclusion in klipper,
 # more information here, https://github.com/Annex-Engineering/Quickdraw_Probe/tree/main/Klipper_Macros
 # User richardjm revised the macro variables and added some functions, thanks a lot
 # by standing on the shoulders of giants, lets see if we can see further
 #
-# the current home for this version is https://github.com/jlas1/Klicky-Probe 
+# the current home for this version is https://github.com/jlas1/Klicky-Probe
 # the 1000 values below is to give an error instead of doing something wrong, hopefully, this won't be used is a printer larger than 1 meter
 
 [gcode_macro _User_Variables]
@@ -33,7 +33,7 @@ variable_z_endstop_x:         1000
 variable_z_endstop_y:         1000
 
 #Check the printer specific documentation on klipper Dock/Undock configuration, these are dummy values
-#dock location 
+#dock location
 variable_docklocation_x:      1000    # X Dock position
 variable_docklocation_y:      1000    # Y Dock position
 variable_docklocation_z:      -128    # Z dock position (-128 for a gantry/frame mount)
@@ -76,12 +76,14 @@ Variable_attachmove2_x:          0    # intermediate toolhead movement to attach
 Variable_attachmove2_y:          0    # the probe on the dock
 Variable_attachmove2_z:          0    # (can be negative)
 
-variable_home_backoff:          10    # how many mm to move away from the endstop after homing
+variable_home_backoff_x:        10    # how many mm to move away from the X endstop after homing X
+                                      # this is useful for the voron v0 to enable the toolhead to move out of the way to allow an unstricted Y homing
+variable_home_backoff_y:         0    # how many mm to move away from the Y endstop after homing Y
 
 variable_override_homing:        ''   # configures what axis to home first
-                                      #  '' = default klicky behavior (tries to avoid the hitting the dock
-                                      # 'X' = forces X to home first 
-                                      # 'Y' = forces Y to home first  
+                                      #  '' = default klicky behavior (tries to avoid the hitting the dock)
+                                      # 'X' = forces X to home first
+                                      # 'Y' = forces Y to home first
 
 # Do not modify below
 gcode:

--- a/Klipper_macros/klicky-variables.cfg
+++ b/Klipper_macros/klicky-variables.cfg
@@ -78,7 +78,7 @@ Variable_attachmove2_z:          0    # (can be negative)
 
 variable_home_backoff_x:        10    # how many mm to move away from the X endstop after homing X
                                       # this is useful for the voron v0 to enable the toolhead to move out of the way to allow an unstricted Y homing
-variable_home_backoff_y:         0    # how many mm to move away from the Y endstop after homing Y
+variable_home_backoff_y:        10    # how many mm to move away from the Y endstop after homing Y
 
 variable_override_homing:        ''   # configures what axis to home first
                                       #  '' = default klicky behavior (tries to avoid the hitting the dock)


### PR DESCRIPTION
I have a voron v0.1 which has a toolhead that crashes into the AB motor mount when homing Y after homing X.

To workaround the toolhead not being able to engage the Y endstop, I  increased `home_backoff` to 23mm to get a safe Y homing.

The current macro also moves the Y carriage off the endstop by the same amount.

This PR splits the `home_backoff` variable into separate values for X and Y.

Signed-off-by: Andrew Basson <andrew.basson@gmail.com>