### PR TITLE
Update klicky-macros.cfg

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -330,7 +330,7 @@ gcode:
 description: Docks Klicky Probe
 gcode:
     # See if the position should be restored after the dock
-    {% set goback  = params.back|default(0) %}
+    {% set goback  = params.BACK|default(0) %}
     # Get probe attach status
     {% set probe_attached = printer["gcode_macro _Probe_Variables"].probe_attached %}
     {% set probe_lock = printer["gcode_macro _Probe_Variables"].probe_lock %}


### PR DESCRIPTION
Klipper Input parameters are Case sensitive and need to be all upper-case IIRC. Just found this when attempting to do a Dock Probe with a return to previous location