### PR TITLE
Add function to exclude Z on tool head parking

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -874,16 +874,16 @@ gcode:
             { action_respond_info("Parking Toolhead") }
         {% endif %}
         {% if parkposition_z == -128 %}
-            { 
-                _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}"
-                G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}
-            }
+            _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}"
+            G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}
+            
         {% else %}
-            {
+        
             _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}"
             G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
-            }
-            {% endif %}
+            
+        {% endif %}
+        
     {% endif %}
     _exit_point function=Park_Toolhead
 

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -873,8 +873,17 @@ gcode:
         {% if verbose %}
             { action_respond_info("Parking Toolhead") }
         {% endif %}
-        _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}"
-        G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
+        {% if parkposition_z == '-128' %}
+            { 
+                _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}"
+                G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}
+            }
+        {% else %}
+            {
+            _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}"
+            G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
+            }
+            {% endif %}
     {% endif %}
     _exit_point function=Park_Toolhead
 

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -873,7 +873,7 @@ gcode:
         {% if verbose %}
             { action_respond_info("Parking Toolhead") }
         {% endif %}
-        {% if parkposition_z == '-128' %}
+        {% if parkposition_z == -128 %}
             { 
                 _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}"
                 G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}

--- a/Klipper_macros/klicky-variables.cfg
+++ b/Klipper_macros/klicky-variables.cfg
@@ -66,7 +66,7 @@ variable_umbilical_y:           15    # Y umbilical position
 variable_park_toolhead:      False    # Enable toolhead parking
 variable_parkposition_x:       125
 variable_parkposition_y:       125
-variable_parkposition_z:        30
+variable_parkposition_z:        30    # -128 excludes Z - Park only on X-Y
 
 variable_version:                1    # Helps users to update the necessary variables, do not update if the variables above are not updated
 


### PR DESCRIPTION
This change allows the tool head Z parking variable to be set to -128 to exclude Z from the parking macro. 

When Z is set to -128 parking will only happen on X and Y axis. 

