### PR TITLE
Added M401 & M402 G-code support

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -322,7 +322,16 @@ gcode:
     {% endif %}
 
     _exit_point function=Attach_Probe
-
+    
+####################
+# Attach Probe G-code
+[gcode_macro M401]
+description: Deploy probe
+variable_deploy_command: 'Attach_Probe'
+gcode:
+    {% if printer['gcode_macro M401'].deploy_command != null %}
+      {deploy_command}
+    {% endif %}
 
 ####################
 # Dock Probe Routine
@@ -443,6 +452,16 @@ gcode:
     {% endif %}
 
     _exit_point function=Dock_Probe move={goback}
+    
+####################
+# Dock Probe G-code
+[gcode_macro M402]
+description: Stow probe
+variable_stow_command: 'Dock_Probe'
+gcode:
+    {% if printer['gcode_macro M402'].stow_command != null %}
+      {stow_command}
+    {% endif %}
 
 #################
 # Probe Calibrate


### PR DESCRIPTION
M401/M402 are standard gcode in Marlin firmware to deploy and stow a dockable probe. This may help some users who are used to using these commands when using the Klicky Probe.