### PR TITLE
Suggestions for better handling of klicky and purge bucket with park enabled. Option to control QGL acceleration

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -918,7 +918,7 @@ gcode:
 
         {% if parkposition_z == -128 %}
             _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}"
-            G0 X{parkposition_x} Y{parkposition_} F{travel_feedrate}
+            G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}
         {% else %}
         _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}"
             {% if not x_y_z_in_order %}   

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -908,7 +908,7 @@ gcode:
             G0 X{parkposition_x} Y{parkposition_} F{travel_feedrate}
         {% else %}
         _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}"
-            {% if not park_z_last %}   
+            {% if not x_y_z_in_order %}   
                 G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
             {% else %}
                 G0 X{parkposition_x} F{travel_feedrate}

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -364,7 +364,8 @@ gcode:
     {% else %}
         _KlickyDebug msg="Attach_Probe probe docking bypassed, doing nothing"
     {% endif %}
-
+    # separated axis movements 
+    {% set x_y_z_in_order = printer["gcode_macro _User_Variables"].x_y_z_in_order %}
 
     {% if bypass_probe_docking == False %}
         _entry_point function=Dock_Probe
@@ -391,7 +392,6 @@ gcode:
 
             # Probe entry location
             _KlickyDebug msg="Dock_Probe moving near the dock with G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}"
-            {% set x_y_z_in_order = printer["gcode_macro _User_Variables"].x_y_z_in_order %}
             {% if not x_y_z_in_order %}   
                 G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}
             {% else %}
@@ -427,9 +427,14 @@ gcode:
             _RetractKlickyDock
 
             #Do an extra move away
-            _KlickyDebug msg="Dock_Probe moving away from the dock to G0 X{docklocation_x|int + dockmove_x|int - attachmove_x|int} Y{docklocation_y|int + dockmove_y|int - attachmove_y|int} F{release_feedrate}"
-            G0 X{docklocation_x|int + dockmove_x|int - attachmove_x|int} Y{docklocation_y|int + dockmove_y|int - attachmove_y|int} F{release_feedrate}
-
+            _KlickyDebug msg="Dock_Probe moving away from the dock to G0 X{docklocation_x|int + dockmove_x|int - attachmove_x|int} Y{docklocation_y|int + dockmove_y|int - attachmove_y|int} F{release_feedrate}"         
+            {% if not x_y_z_in_order %} 
+                G0 X{docklocation_x|int + dockmove_x|int - attachmove_x|int} Y{docklocation_y|int + dockmove_y|int - attachmove_y|int} F{release_feedrate}
+            {% else %}
+                # Y movement is unecessary for the purge bucket
+                G0 X{docklocation_x|int + dockmove_x|int - attachmove_x|int} F{release_feedrate} 
+            {% endif %}
+            
             ## Go to Z safe distance
             {% if ((printer.toolhead.position.z < safe_z) or (docklocation_z != -128 and docklocation_z < safe_z ))%}
               _KlickyDebug msg="Dock_Probe moving to a safe Z position: G0 Z{safe_z} F{z_drop_feedrate} from {printer.toolhead.position.z}"

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -908,8 +908,8 @@ gcode:
         {% else %}
 
             _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}"
-            G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
-
+            G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}
+            G0 Z{parkposition_z} F{travel_feedrate}
         {% endif %}
 
     {% endif %}

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -67,6 +67,7 @@ gcode:
     G90
     # set a safe(sane) Acceleration
     SET_VELOCITY_LIMIT ACCEL={move_accel}
+    SET_VELOCITY_LIMIT ACCEL_TO_DECEL={ (move_accel / 2)|int }
 
 [gcode_macro _Homing_Variables]
 gcode:

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -911,8 +911,10 @@ gcode:
             {% if not park_z_last %}   
                 G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
             {% else %}
-                G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}
+                G0 X{parkposition_x} F{travel_feedrate}
+                G0 Y{parkposition_y} F{travel_feedrate} 
                 G0 Z{parkposition_z} F{travel_feedrate}
+            {% endif %}
             {% endif %}
         {% endif %}
 

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -391,7 +391,14 @@ gcode:
 
             # Probe entry location
             _KlickyDebug msg="Dock_Probe moving near the dock with G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}"
-            G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}
+            {% set x_y_z_in_order = printer["gcode_macro _User_Variables"].x_y_z_in_order %}
+            {% if not x_y_z_in_order %}   
+                G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}
+            {% else %}
+                G0 Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}
+                G0 X{docklocation_x|int - attachmove_x|int} F{travel_feedrate}
+            {% endif %}
+            
             {% if docklocation_z != -128 %}
                 _KlickyDebug msg="Dock_Probe moving near the dock with G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}"
                 G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -893,7 +893,7 @@ gcode:
     {% set parkposition_y = printer["gcode_macro _User_Variables"].parkposition_y %}
     {% set parkposition_z = printer["gcode_macro _User_Variables"].parkposition_z %}
     {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
-    {% set park_z_last = printer["gcode_macro _User_Variables"].x_y_z_in_order %}
+    {% set x_y_z_in_order = printer["gcode_macro _User_Variables"].x_y_z_in_order %}
     {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
 
     _entry_point function=Park_Toolhead

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -897,13 +897,16 @@ gcode:
     {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
 
     _entry_point function=Park_Toolhead
-
     {% if park_toolhead and 'xyz' in printer.toolhead.homed_axes %}
-    
+
         {% if verbose %}
             { action_respond_info("Parking Toolhead") }
         {% endif %}
-        
+
+        {% if parkposition_z == -128 %}
+            _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}"
+            G0 X{parkposition_x} Y{parkposition_} F{travel_feedrate}
+        {% else %}
         _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}"
         {% if not park_z_last %}   
             G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
@@ -911,7 +914,7 @@ gcode:
             G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}
             G0 Z{parkposition_z} F{travel_feedrate}
         {% endif %}
-        
+
     {% endif %}
     _exit_point function=Park_Toolhead
 

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -893,25 +893,25 @@ gcode:
     {% set parkposition_y = printer["gcode_macro _User_Variables"].parkposition_y %}
     {% set parkposition_z = printer["gcode_macro _User_Variables"].parkposition_z %}
     {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
+    {% set park_z_last = printer["gcode_macro _User_Variables"].park_z_last %}
     {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
 
     _entry_point function=Park_Toolhead
 
     {% if park_toolhead and 'xyz' in printer.toolhead.homed_axes %}
+    
         {% if verbose %}
             { action_respond_info("Parking Toolhead") }
         {% endif %}
-        {% if parkposition_z == -128 %}
-            _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}"
-            G0 X{parkposition_x} Y{parkposition_} F{travel_feedrate}
-
+        
+        _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}"
+        {% if not park_z_last %}   
+            G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
         {% else %}
-
-            _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}"
             G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}
             G0 Z{parkposition_z} F{travel_feedrate}
         {% endif %}
-
+        
     {% endif %}
     _exit_point function=Park_Toolhead
 

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -908,11 +908,12 @@ gcode:
             G0 X{parkposition_x} Y{parkposition_} F{travel_feedrate}
         {% else %}
         _KlickyDebug msg="_Park_Toolhead moving to G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}"
-        {% if not park_z_last %}   
-            G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
-        {% else %}
-            G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}
-            G0 Z{parkposition_z} F{travel_feedrate}
+            {% if not park_z_last %}   
+                G0 X{parkposition_x} Y{parkposition_y} Z{parkposition_z} F{travel_feedrate}
+            {% else %}
+                G0 X{parkposition_x} Y{parkposition_y} F{travel_feedrate}
+                G0 Z{parkposition_z} F{travel_feedrate}
+            {% endif %}
         {% endif %}
 
     {% endif %}

--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -893,7 +893,7 @@ gcode:
     {% set parkposition_y = printer["gcode_macro _User_Variables"].parkposition_y %}
     {% set parkposition_z = printer["gcode_macro _User_Variables"].parkposition_z %}
     {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
-    {% set park_z_last = printer["gcode_macro _User_Variables"].park_z_last %}
+    {% set park_z_last = printer["gcode_macro _User_Variables"].x_y_z_in_order %}
     {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
 
     _entry_point function=Park_Toolhead

--- a/Klipper_macros/klicky-quad-gantry-level.cfg
+++ b/Klipper_macros/klicky-quad-gantry-level.cfg
@@ -16,6 +16,7 @@ rename_existing: _QUAD_GANTRY_LEVEL
 description: Conform a moving, twistable gantry to the shape of a stationary bed with klicky automount
 gcode:
     {% set V = printer["gcode_macro _User_Variables"].verbose %}
+    {% set accel = printer["gcode_macro _User_Variables"].level_gantry_accel %} 
     {% if V %}
         { action_respond_info("QG Level") }
     {% endif %}
@@ -24,8 +25,11 @@ gcode:
 	G90
     Attach_Probe
     _KLICKY_STATUS_LEVELING
-
+    M400
+    SET_VELOCITY_LIMIT ACCEL={accel}
     _QUAD_GANTRY_LEVEL {% for p in params
             %}{'%s=%s ' % (p, params[p])}{%
             endfor %}
+    M400
+    SET_VELOCITY_LIMIT ACCEL={printer.configfile.settings.printer.max_accel}
     Dock_Probe

--- a/Klipper_macros/klicky-quad-gantry-level.cfg
+++ b/Klipper_macros/klicky-quad-gantry-level.cfg
@@ -30,6 +30,6 @@ gcode:
     _QUAD_GANTRY_LEVEL {% for p in params
             %}{'%s=%s ' % (p, params[p])}{%
             endfor %}
+    Dock_Probe
     M400
     SET_VELOCITY_LIMIT ACCEL={printer.configfile.settings.printer.max_accel}
-    Dock_Probe

--- a/Klipper_macros/klicky-quad-gantry-level.cfg
+++ b/Klipper_macros/klicky-quad-gantry-level.cfg
@@ -20,16 +20,18 @@ gcode:
     {% if V %}
         { action_respond_info("QG Level") }
     {% endif %}
-
+  
     _CheckProbe action=query
-	G90
+    G90
     Attach_Probe
     _KLICKY_STATUS_LEVELING
     M400
     SET_VELOCITY_LIMIT ACCEL={accel}
+    SET_VELOCITY_LIMIT ACCEL_TO_DECEL={ (accel / 2)|int}
     _QUAD_GANTRY_LEVEL {% for p in params
             %}{'%s=%s ' % (p, params[p])}{%
             endfor %}
     Dock_Probe
     M400
     SET_VELOCITY_LIMIT ACCEL={printer.configfile.settings.printer.max_accel}
+    SET_VELOCITY_LIMIT ACCEL_TO_DECEL={printer.configfile.settings.printer.max_accel_to_decel}

--- a/Klipper_macros/klicky-variables.cfg
+++ b/Klipper_macros/klicky-variables.cfg
@@ -64,6 +64,7 @@ variable_umbilical_y:           15    # Y umbilical position
 
 # location to park the toolhead
 variable_park_toolhead:      False    # Enable toolhead parking
+variable_park_z_last:         True    # If true, Z movement is standalone after X/Y, prevents head hits on way to the purge bucket.
 variable_parkposition_x:       125
 variable_parkposition_y:       125
 variable_parkposition_z:        30    # -128 excludes Z - Park only on X-Y

--- a/Klipper_macros/klicky-variables.cfg
+++ b/Klipper_macros/klicky-variables.cfg
@@ -64,7 +64,7 @@ variable_umbilical_y:           15    # Y umbilical position
 
 # location to park the toolhead
 variable_park_toolhead:      False    # Enable toolhead parking
-variable_park_z_last:         True    # If true, Z movement is standalone after X/Y, prevents head hits on way to the purge bucket.
+variable_x_y_z_in_order:      True    # If true, it first moves x then y and finally z. This prevents head hits on way to the purge bucket.
 variable_parkposition_x:       125
 variable_parkposition_y:       125
 variable_parkposition_z:        30    # -128 excludes Z - Park only on X-Y

--- a/Klipper_macros/klicky-variables.cfg
+++ b/Klipper_macros/klicky-variables.cfg
@@ -15,6 +15,7 @@ variable_verbose:             True    # Enable verbose output
 variable_debug:              False    # Enable Debug output
 variable_travel_speed:         200    # how fast all other travel moves will be performed when running these macros
 variable_move_accel:          1000    # how fast should the toolhead accelerate when moving
+variable_level_gantry_accel:  1000    # how fast should the toolhead accelerate when moving when doing gantry level
 variable_dock_speed:            50    # how fast should the toolhead move when docking the probe for the final movement
 variable_release_speed:         75    # how fast should the toolhead move to release the hold of the magnets after docking
 variable_z_drop_speed:          20    # how fast the z will lower when moving to the z location to clear the probe


### PR DESCRIPTION
This little suggestion let's us park the toolhead on the purge bucket, especially on the left  location, without having the probe hit anything since each axis movement is standalone. It is user optional by setting variable_x_y_z_in_order: in klicky-variables.cfg to true. Also it is now possible to set QGL travel acceleration to the user preference via variable_level_gantry_accel: 