### PR TITLE
Remove integer truncation from various positions

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -115,9 +115,9 @@ gcode:
 description: Deploys Klicky servo-controlled dock
 gcode:
     {% set enable_dock_servo = printer["gcode_macro _User_Variables"].enable_dock_servo|default(False) %}
-    {% set servo_delay = printer["gcode_macro _User_Variables"].servo_delay|default(1000) %}
+    {% set servo_delay = printer["gcode_macro _User_Variables"].servo_delay|default(1000)|int %}
     {% set servo_name = printer["gcode_macro _User_Variables"].servo_name %}
-    {% set servo_deploy = printer["gcode_macro _User_Variables"].servo_deploy|default(360) %}
+    {% set servo_deploy = printer["gcode_macro _User_Variables"].servo_deploy|default(360)|float %}
 
     #wait for all the moves to complete
     M400
@@ -126,10 +126,10 @@ gcode:
         {% if servo_deploy == 360 %}
             { action_raise_error("Klicky: servo active on klicky-variables, but no servo deploy angle specified") }
         {% endif %}
-        _KlickyDebug msg="_DeployKlickyDock SET_SERVO SERVO={servo_name|string} ANGLE={servo_deploy|int}"
-        SET_SERVO SERVO={servo_name|string} ANGLE={servo_deploy|int}
+        _KlickyDebug msg="_DeployKlickyDock SET_SERVO SERVO={servo_name|string} ANGLE={servo_deploy}"
+        SET_SERVO SERVO={servo_name|string} ANGLE={servo_deploy}
         M400
-        G4 P{servo_delay|int}
+        G4 P{servo_delay}
         _KlickyDebug msg="_DeployKlickyDock SET_SERVO SERVO={servo_name|string} WIDTH=0"
         SET_SERVO SERVO={servo_name|string} WIDTH=0
     {% elif printer["gcode_macro _DeployDock"] is defined %}
@@ -144,9 +144,9 @@ gcode:
 description: Retracts Klicky servo-controlled dock
 gcode:
     {% set enable_dock_servo = printer["gcode_macro _User_Variables"].enable_dock_servo|default(False) %}
-    {% set servo_delay = printer["gcode_macro _User_Variables"].servo_delay|default(1000) %}
+    {% set servo_delay = printer["gcode_macro _User_Variables"].servo_delay|default(1000)|int %}
     {% set servo_name = printer["gcode_macro _User_Variables"].servo_name %}
-    {% set servo_retract = printer["gcode_macro _User_Variables"].servo_retract|default(360) %}
+    {% set servo_retract = printer["gcode_macro _User_Variables"].servo_retract|default(360)|float %}
 
     #wait for all the moves to complete
     M400
@@ -155,10 +155,10 @@ gcode:
         {% if servo_retract == 360 %}
             { action_raise_error("Klicky: servo active on klicky-variables, but no servo retract angle specified") }
         {% endif %}
-        _KlickyDebug msg="_RetractKlickyDock SET_SERVO SERVO={servo_name|string} ANGLE={servo_retract|int}"
-        SET_SERVO SERVO={servo_name|string} ANGLE={servo_retract|int}
+        _KlickyDebug msg="_RetractKlickyDock SET_SERVO SERVO={servo_name|string} ANGLE={servo_retract}"
+        SET_SERVO SERVO={servo_name|string} ANGLE={servo_retract}
         M400
-        G4 P{servo_delay|int}
+        G4 P{servo_delay}
         _KlickyDebug msg="_RetractKlickyDock SET_SERVO SERVO={servo_name|string} WIDTH=0"
         SET_SERVO SERVO={servo_name|string} WIDTH=0
     {% elif printer["gcode_macro _RetractDock"] is defined %}
@@ -179,18 +179,18 @@ gcode:
     {% set probe_lock = printer["gcode_macro _Probe_Variables"].probe_lock %}
     {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
     # Get Docking location
-    {% set dockmove_x = printer["gcode_macro _User_Variables"].dockmove_x|default(0) %}
-    {% set dockmove_y = printer["gcode_macro _User_Variables"].dockmove_y|default(0) %}
-    {% set dockmove_z = printer["gcode_macro _User_Variables"].dockmove_z|default(0) %}
-    {% set docklocation_x = printer["gcode_macro _User_Variables"].docklocation_x %}
-    {% set docklocation_y = printer["gcode_macro _User_Variables"].docklocation_y %}
-    {% set docklocation_z = printer["gcode_macro _User_Variables"].docklocation_z %}
-    {% set attachmove_x = printer["gcode_macro _User_Variables"].attachmove_x|default(0) %}
-    {% set attachmove_y = printer["gcode_macro _User_Variables"].attachmove_y|default(0) %}
-    {% set attachmove_z = printer["gcode_macro _User_Variables"].attachmove_z|default(0) %}
-    {% set attachmove2_x = printer["gcode_macro _User_Variables"].attachmove2_x|default(0) %}
-    {% set attachmove2_y = printer["gcode_macro _User_Variables"].attachmove2_y|default(0) %}
-    {% set attachmove2_z = printer["gcode_macro _User_Variables"].attachmove2_z|default(0) %}
+    {% set dockmove_x = printer["gcode_macro _User_Variables"].dockmove_x|default(0)|float %}
+    {% set dockmove_y = printer["gcode_macro _User_Variables"].dockmove_y|default(0)|float %}
+    {% set dockmove_z = printer["gcode_macro _User_Variables"].dockmove_z|default(0)|float %}
+    {% set docklocation_x = printer["gcode_macro _User_Variables"].docklocation_x|float %}
+    {% set docklocation_y = printer["gcode_macro _User_Variables"].docklocation_y|float %}
+    {% set docklocation_z = printer["gcode_macro _User_Variables"].docklocation_z|float %}
+    {% set attachmove_x = printer["gcode_macro _User_Variables"].attachmove_x|default(0)|float %}
+    {% set attachmove_y = printer["gcode_macro _User_Variables"].attachmove_y|default(0)|float %}
+    {% set attachmove_z = printer["gcode_macro _User_Variables"].attachmove_z|default(0)|float %}
+    {% set attachmove2_x = printer["gcode_macro _User_Variables"].attachmove2_x|default(0)|float %}
+    {% set attachmove2_y = printer["gcode_macro _User_Variables"].attachmove2_y|default(0)|float %}
+    {% set attachmove2_z = printer["gcode_macro _User_Variables"].attachmove2_z|default(0)|float %}
     # Safe Z for travel
     {% set safe_z = printer["gcode_macro _User_Variables"].safe_z %}
     {% set enable_z_hop = printer["gcode_macro _User_Variables"].enable_z_hop %}
@@ -258,13 +258,13 @@ gcode:
             _entry_point function=Attach_Probe_intern
 
             # Probe entry location
-            _KlickyDebug msg="Attach_Probe moving near the dock with G0 X{docklocation_x|int - attachmove_x|int - attachmove2_x|int} Y{docklocation_y|int - attachmove_y|int - attachmove2_y} F{travel_feedrate}"
-            G0 X{docklocation_x|int - attachmove_x|int - attachmove2_x|int} Y{docklocation_y|int - attachmove_y|int - attachmove2_y} F{travel_feedrate}
+            _KlickyDebug msg="Attach_Probe moving near the dock with G0 X{docklocation_x - attachmove_x - attachmove2_x} Y{docklocation_y - attachmove_y - attachmove2_y} F{travel_feedrate}"
+            G0 X{docklocation_x - attachmove_x - attachmove2_x} Y{docklocation_y - attachmove_y - attachmove2_y} F{travel_feedrate}
             {% if docklocation_z != -128 %}
-                _KlickyDebug msg="Attach_Probe moving near the dock with G0 Z{docklocation_z|int - attachmove_z|int - attachmove2_z|int} F{dock_feedrate}"
-                G0 Z{docklocation_z|int - attachmove_z|int - attachmove2_z|int} F{dock_feedrate}
-                _KlickyDebug msg="Attach_Probe moving near the dock with G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}"
-                G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}
+                _KlickyDebug msg="Attach_Probe moving near the dock with G0 Z{docklocation_z - attachmove_z - attachmove2_z} F{dock_feedrate}"
+                G0 Z{docklocation_z - attachmove_z - attachmove2_z} F{dock_feedrate}
+                _KlickyDebug msg="Attach_Probe moving near the dock with G0 Z{docklocation_z - attachmove_z} F{dock_feedrate}"
+                G0 Z{docklocation_z - attachmove_z} F{dock_feedrate}
 				{% endif %}
             # if necessary do some actions before moving the toolhead to dock
             _DeployKlickyDock
@@ -274,17 +274,17 @@ gcode:
                 _KlickyDebug msg="Attach_Probe moving to the dock with G0 Z{docklocation_z} F{dock_feedrate}"
                 G0 Z{docklocation_z} F{dock_feedrate}
             {% endif %}
-            _KlickyDebug msg="Attach_Probe moving to the dock with G0 X{docklocation_x|int - attachmove2_x|int} Y{docklocation_y|int - attachmove2_y} F{dock_feedrate}"
-            G0 X{docklocation_x|int - attachmove2_x|int} Y{docklocation_y|int - attachmove2_y} F{dock_feedrate}
+            _KlickyDebug msg="Attach_Probe moving to the dock with G0 X{docklocation_x - attachmove2_x} Y{docklocation_y - attachmove2_y} F{dock_feedrate}"
+            G0 X{docklocation_x - attachmove2_x} Y{docklocation_y - attachmove2_y} F{dock_feedrate}
             _KlickyDebug msg="Attach_Probe moving to the dock with G0 X{docklocation_x} Y{docklocation_y} F{dock_feedrate}"
             G0 X{docklocation_x} Y{docklocation_y} F{dock_feedrate}
             # Probe Attached
             {% if docklocation_z != -128 %}
-                _KlickyDebug msg="Attach_Probe moving from the dock to G0 Z{docklocation_z|int - attachmove_z|int} F{z_drop_feedrate}"
-                G0 Z{docklocation_z|int - attachmove_z|int} F{z_drop_feedrate}
+                _KlickyDebug msg="Attach_Probe moving from the dock to G0 Z{docklocation_z - attachmove_z} F{z_drop_feedrate}"
+                G0 Z{docklocation_z - attachmove_z} F{z_drop_feedrate}
             {% endif %}
-            _KlickyDebug msg="Attach_Probe moving from the dock to G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{release_feedrate}"
-            G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{release_feedrate}
+            _KlickyDebug msg="Attach_Probe moving from the dock to G0 X{docklocation_x - attachmove_x} Y{docklocation_y - attachmove_y} F{release_feedrate}"
+            G0 X{docklocation_x - attachmove_x} Y{docklocation_y - attachmove_y} F{release_feedrate}
             # if necessary do some actions after attaching the probe
             _RetractKlickyDock
             ## Go to Z safe distance
@@ -338,15 +338,15 @@ gcode:
     {% set probe_lock = printer["gcode_macro _Probe_Variables"].probe_lock %}
     {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
     # Get Docking location
-    {% set dockmove_x = printer["gcode_macro _User_Variables"].dockmove_x|default(0) %}
-    {% set dockmove_y = printer["gcode_macro _User_Variables"].dockmove_y|default(0) %}
-    {% set dockmove_z = printer["gcode_macro _User_Variables"].dockmove_z|default(0) %}
-    {% set docklocation_x = printer["gcode_macro _User_Variables"].docklocation_x %}
-    {% set docklocation_y = printer["gcode_macro _User_Variables"].docklocation_y %}
-    {% set docklocation_z = printer["gcode_macro _User_Variables"].docklocation_z %}
-    {% set attachmove_x = printer["gcode_macro _User_Variables"].attachmove_x|default(0) %}
-    {% set attachmove_y = printer["gcode_macro _User_Variables"].attachmove_y|default(0) %}
-    {% set attachmove_z = printer["gcode_macro _User_Variables"].attachmove_z|default(0) %}
+    {% set dockmove_x = printer["gcode_macro _User_Variables"].dockmove_x|default(0)|float %}
+    {% set dockmove_y = printer["gcode_macro _User_Variables"].dockmove_y|default(0)|float %}
+    {% set dockmove_z = printer["gcode_macro _User_Variables"].dockmove_z|default(0)|float %}
+    {% set docklocation_x = printer["gcode_macro _User_Variables"].docklocation_x|float %}
+    {% set docklocation_y = printer["gcode_macro _User_Variables"].docklocation_y|float %}
+    {% set docklocation_z = printer["gcode_macro _User_Variables"].docklocation_z|float %}
+    {% set attachmove_x = printer["gcode_macro _User_Variables"].attachmove_x|default(0)|float %}
+    {% set attachmove_y = printer["gcode_macro _User_Variables"].attachmove_y|default(0)|float %}
+    {% set attachmove_z = printer["gcode_macro _User_Variables"].attachmove_z|default(0)|float %}
     # Safe Z for travel
     {% set safe_z = printer["gcode_macro _User_Variables"].safe_z|float %}
     # Set feedrates
@@ -372,12 +372,12 @@ gcode:
           _Umbilical_Path
 
           # Probe entry location
-          _KlickyDebug msg="Dock_Probe moving near the dock with G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}"
-          G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}
+          _KlickyDebug msg="Dock_Probe moving near the dock with G0 X{docklocation_x - attachmove_x} Y{docklocation_y - attachmove_y} F{travel_feedrate}"
+          G0 X{docklocation_x - attachmove_x} Y{docklocation_y - attachmove_y} F{travel_feedrate}
 
           {% if docklocation_z != -128 %}
-            _KlickyDebug msg="Dock_Probe moving near the dock with G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}"
-            G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}
+            _KlickyDebug msg="Dock_Probe moving near the dock with G0 Z{docklocation_z - attachmove_z} F{dock_feedrate}"
+            G0 Z{docklocation_z - attachmove_z} F{dock_feedrate}
           {% endif %}
 
           # if necessary do some actions before moving the toolhead to dock
@@ -394,19 +394,19 @@ gcode:
 
           # Probe decoupling
           {% if docklocation_z != -128 %}
-            _KlickyDebug msg="Dock_Probe moving from the dock to G0 Z{docklocation_z|int + dockmove_z|int} F{release_feedrate}"
-            G0 Z{docklocation_z|int + dockmove_z|int} F{release_feedrate}
+            _KlickyDebug msg="Dock_Probe moving from the dock to G0 Z{docklocation_z + dockmove_z} F{release_feedrate}"
+            G0 Z{docklocation_z + dockmove_z} F{release_feedrate}
           {% endif %}
 
-          _KlickyDebug msg="Dock_Probe moving from the dock to G0 X{docklocation_x|int + dockmove_x|int} Y{docklocation_y|int + dockmove_y|int} F{release_feedrate}"
-          G0 X{docklocation_x|int + dockmove_x|int} Y{docklocation_y|int + dockmove_y|int} F{release_feedrate}
+          _KlickyDebug msg="Dock_Probe moving from the dock to G0 X{docklocation_x + dockmove_x} Y{docklocation_y + dockmove_y} F{release_feedrate}"
+          G0 X{docklocation_x + dockmove_x} Y{docklocation_y + dockmove_y} F{release_feedrate}
 
           # if necessary do some actions after attaching the probe
           _RetractKlickyDock
 
           #Do an extra move away
-          _KlickyDebug msg="Dock_Probe moving away from the dock to G0 X{docklocation_x|int + dockmove_x|int - attachmove_x|int} Y{docklocation_y|int + dockmove_y|int - attachmove_y|int} F{release_feedrate}"
-          G0 X{docklocation_x|int + dockmove_x|int - attachmove_x|int} Y{docklocation_y|int + dockmove_y|int - attachmove_y|int} F{release_feedrate}
+          _KlickyDebug msg="Dock_Probe moving away from the dock to G0 X{docklocation_x + dockmove_x - attachmove_x} Y{docklocation_y + dockmove_y - attachmove_y} F{release_feedrate}"
+          G0 X{docklocation_x + dockmove_x - attachmove_x} Y{docklocation_y + dockmove_y - attachmove_y} F{release_feedrate}
 
           ## Go to Z safe distance
           {% if (printer.gcode_move.gcode_position.z < safe_z) %}
@@ -560,13 +560,11 @@ gcode:
     {% set enable_z_hop = printer["gcode_macro _User_Variables"].enable_z_hop %}
     {% set kinematic_z = 0 %}
     {% set dock_on_zhome = printer["gcode_macro _User_Variables"].dock_on_zhome|default(True) %}
-    {% set attachmove_x = printer["gcode_macro _User_Variables"].attachmove_x|default(0) %}
-    {% set attachmove_y = printer["gcode_macro _User_Variables"].attachmove_y|default(0) %}
-    {% set attachmove_z = printer["gcode_macro _User_Variables"].attachmove_z|default(0) %}
+    {% set attachmove_y = printer["gcode_macro _User_Variables"].attachmove_y|default(0)|float %}
     {% set z_drop_feedrate = printer["gcode_macro _User_Variables"].z_drop_speed * 60 %}
     {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
-    {% set home_backoff_x = printer["gcode_macro _User_Variables"].home_backoff_x|default(0) %}
-    {% set home_backoff_y = printer["gcode_macro _User_Variables"].home_backoff_y|default(0) %}
+    {% set home_backoff_x = printer["gcode_macro _User_Variables"].home_backoff_x|default(0)|float %}
+    {% set home_backoff_y = printer["gcode_macro _User_Variables"].home_backoff_y|default(0)|float %}
     {% set override_homing = printer["gcode_macro _User_Variables"].override_homing|default('') %}
 
     #checks if the variable definitions are up to date
@@ -689,11 +687,11 @@ gcode:
                 # does it need to back away from the home position
                 {% if home_backoff_y != 0 %}
                     {% if (printer.configfile.settings.stepper_y.position_endstop > (printer.configfile.settings.stepper_y.position_min|default(0) + printer.configfile.settings.stepper_y.position_max)/2) %}
-                        _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop-home_backoff_y|int} F{travel_feedrate}"
-                        G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff_y|int} F{travel_feedrate}
+                        _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop-home_backoff_y} F{travel_feedrate}"
+                        G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff_y} F{travel_feedrate}
                     {% else %}
-                        _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y|int} F{travel_feedrate}"
-                        G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y|int} F{travel_feedrate}
+                        _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y} F{travel_feedrate}"
+                        G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y} F{travel_feedrate}
                     {%endif %}
                 {%endif %}
             {% endif %}
@@ -723,11 +721,11 @@ gcode:
             # does it need to back away from the home position
             {% if home_backoff_x != 0 %}
                 {% if (printer.configfile.settings.stepper_x.position_endstop > (printer.configfile.settings.stepper_x.position_min|default(0) + printer.configfile.settings.stepper_x.position_max)/2) %}
-                    _KlickyDebug msg="homing_override backing off X endstop, G0 X{printer.configfile.settings.stepper_x.position_endstop - home_backoff_x|int} F{travel_feedrate}"
-                    G0 X{printer.configfile.settings.stepper_x.position_endstop - home_backoff_x|int} F{travel_feedrate}
+                    _KlickyDebug msg="homing_override backing off X endstop, G0 X{printer.configfile.settings.stepper_x.position_endstop - home_backoff_x} F{travel_feedrate}"
+                    G0 X{printer.configfile.settings.stepper_x.position_endstop - home_backoff_x} F{travel_feedrate}
                 {% else %}
-                    _KlickyDebug msg="homing_override backing off X endstop, G0 X{printer.configfile.settings.stepper_x.position_endstop + home_backoff_x|int} F{travel_feedrate}"
-                    G0 X{printer.configfile.settings.stepper_x.position_endstop + home_backoff_x|int} F{travel_feedrate}
+                    _KlickyDebug msg="homing_override backing off X endstop, G0 X{printer.configfile.settings.stepper_x.position_endstop + home_backoff_x} F{travel_feedrate}"
+                    G0 X{printer.configfile.settings.stepper_x.position_endstop + home_backoff_x} F{travel_feedrate}
                 {%endif %}
             {%endif %}
         {% endif %}
@@ -753,11 +751,11 @@ gcode:
             G28 Y0
             {% if home_backoff_y != 0 %}
                 {% if (printer.configfile.settings.stepper_y.position_endstop > (printer.configfile.settings.stepper_y.position_min|default(0) + printer.configfile.settings.stepper_y.position_max)/2) %}
-                    _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff_y|int} F{travel_feedrate}"
-                    G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff_y|int} F{travel_feedrate}
+                    _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff_y} F{travel_feedrate}"
+                    G0 Y{printer.configfile.settings.stepper_y.position_endstop - home_backoff_y} F{travel_feedrate}
                 {% else %}
-                    _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y|int} F{travel_feedrate}"
-                    G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y|int} F{travel_feedrate}
+                    _KlickyDebug msg="homing_override backing off Y endstop, G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y} F{travel_feedrate}"
+                    G0 Y{printer.configfile.settings.stepper_y.position_endstop + home_backoff_y} F{travel_feedrate}
                 {%endif %}
             {%endif %}
         {% endif %}


### PR DESCRIPTION
Fixes #159.

This replaces the `|int` truncation of position and motion handling in the klipper macros with `|float`s so that fractional positions work.

Without this my docking would *usually* fail because, with my optimal position being about half a mm away from an integer, I had frequent docking failures where the probe would hit the edge of the dock.

It also simplifies the code to do the conversion-to-float just once for each variable (which I see was also quite correctly advised in #159), rather than having many `|int`s scattered everywhere the variables are used.