### PR TITLE
Fix: Update README.md (missing link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Klicky Probe
 Microswitch probe with magnetic attachment, primarily aimed at CoreXY 3d printers.
 
-Initially it was focused on the [Voron printers](https://vorondesign.com/) (V2.4, V1.8, Trident, V0) and derivatives, now it's been restructured to better allow other printers to be documented here.
+Initially it was focused on the [Voron printers](https://vorondesign.com/) (V2.4, V1.8, Trident, V0) and derivatives, now it's been restructured to better allow other printers to be documented [here](./Printers).
 
 The objectives for this project are:
 - drop in replacement for Omron TL-Q5MC2 or PL-08N2 (you don't need to replace the toolhead), replacement of BLtouch probes


### PR DESCRIPTION
The hyperlink for the directory with the other printers was missing. This pr simply updates the readme with the hyperlink to the relative path.