### PR TITLE
Fixed Climbing Z when homing. New variable added. Made new probe check macro for systems using conditional homing

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -712,7 +712,9 @@ gcode:
             {% if verbose %}
                 { action_respond_info("moving to a safe Z distance") }
             {% endif %}
-            G0 Z{safe_z} F{z_drop_feedrate}
+               {% if printer.gcode_move.gcode_position.z < safe_z %} # 3dpd
+                  G0 Z{safe_z} F{z_drop_feedrate} 
+               {% endif %} # 3dpd
         {% endif %}
         {% if printer["gcode_macro _HOME_X"] is defined %}
             _KlickyDebug msg="homing_override calling _HOME_X external script to handle the X homing"
@@ -743,7 +745,10 @@ gcode:
             {% if verbose %}
                 { action_respond_info("moving to a safe Z distance") }
             {% endif %}
-            G0 Z{safe_z} F{z_drop_feedrate}
+               {% if home_x == True and home_y == True and home_z == True %} # 3dpd
+               {% elif printer.gcode_move.gcode_position.z < safe_z %} # 3dpd  
+                  G0 Z{safe_z} F{z_drop_feedrate}
+               {% endif %} # 3dpd               
         {% endif %}
         {% if printer["gcode_macro _HOME_Y"] is defined %}
             _KlickyDebug msg="homing_override calling _HOME_Y external script to handle the Y homing"
@@ -772,7 +777,10 @@ gcode:
             {% if verbose %}
                 { action_respond_info("moving to a safe Z distance") }
             {% endif %}
-            G0 Z{safe_z} F{z_drop_feedrate}
+             {% if home_x == True and home_y == True and home_z == True %} # 3dpd
+             {% elif printer.gcode_move.gcode_position.z < safe_z %} # 3dpd              
+                G0 Z{safe_z} F{z_drop_feedrate}
+             {% endif %} # 3dpd                  
         {% endif %}
 
         # if probe is configured as endstop, attach it, else check if the probe needs to be docked if attached
@@ -834,6 +842,8 @@ gcode:
     {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}    {% set z_drop_feedrate = printer["gcode_macro _User_Variables"].z_drop_speed * 60 %}
     {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
 
+    {% set post_z_backoff_y = printer["gcode_macro _User_Variables"].post_z_backoff_y|float %}
+
     _entry_point function=Home_Z
 
     # if x and y are not homed yet, raise error
@@ -857,6 +867,9 @@ gcode:
         G28 Z0
         _KlickyDebug msg="_Home_Z_ toolhead too low, raising it to {safe_z}mm from {printer.gcode_move.gcode_position.z}mm"
         G0 Z{safe_z} F{z_drop_feedrate}
+        G91 # 3dpd
+        G0 Y{post_z_backoff_y} F3600 # 3dpd
+        G90 # 3dpd
     {% endif %}
 
     _exit_point function=Home_Z

--- a/Klipper_macros/klicky-variables.cfg
+++ b/Klipper_macros/klicky-variables.cfg
@@ -76,6 +76,10 @@ Variable_attachmove2_x:          0    # intermediate toolhead movement to attach
 Variable_attachmove2_y:          0    # the probe on the dock
 Variable_attachmove2_z:          0    # (can be negative)
 
+variable_post_z_backoff_y:      -0    # relative mode back off the Y axis after Z homing to give sensorless homing systems room to move axis if restarted in home position # 3dpd
+                                      # USE MINUS VALUE IF Z ENDSTOP SWITCH IS TO THE REAR OF YOUR BED! VORON 2.4! 
+
+
 variable_home_backoff_x:        10    # how many mm to move away from the X endstop after homing X
                                       # this is useful for the voron v0 to enable the toolhead to move out of the way to allow an unstricted Y homing
 variable_home_backoff_y:        10    # how many mm to move away from the Y endstop after homing Y


### PR DESCRIPTION
Fixed the climbing Z homing thing if axes are already homed & printer is XYZ homed again. This may cause the machine to top out if the toolhead is near max height. It's also not that great to see it do it low down either tbh. System is set to raise Z once only if below `safe_z` height otherwise normal homing will result.

Added new variable for homing Z where it allows you to back off the Y axis after Z homing for use with sensorless homing systems where the axis will need some travel room to home, especially if the machine is restarted with the toolhead directly above the Z endstop switch at the very back of the printer.

Added a new Macro that checks for probe condition before homing after print error & axes are still enabled when used with conditional homing.

To view changes in files search 3dpd.

Also see probe check macro in 3dpd release v1.0.0 in my fork