### PR TITLE
Adding missing [% %} to line 655

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -652,7 +652,7 @@ gcode:
         {% endif %}
     {% else %}
         _KlickyDebug msg="All axis homed"
-        set safe_z = printer.gcode_move.gcode_position.z|float
+        {% set safe_z = printer.gcode_move.gcode_position.z|float %}
         _KlickyDebug msg="Setting Safe_z to {printer.gcode_move.gcode_position.z}mm as Z is now above configured safe_z"
     {% endif %}
 


### PR DESCRIPTION
Small bit of housekeeping. Line 655:

set safe_z = printer["gcode_macro _User_Variables"].safe_z|float 

missing enclosing curly brackets.