### PR TITLE
Fix goint typo (replace with going)

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -590,23 +590,23 @@ gcode:
         and not 'Z' in params %}
 
         {% set home_x, home_y, home_z = True, True, True %}
-        _KlickyDebug msg="homing_override goint to home all axes"
+        _KlickyDebug msg="homing_override going to home all axes"
 
     {% else %}
         {% if 'X' in params %}
             {% set home_x = True %}
-             _KlickyDebug msg="homing_override goint to home X"
+             _KlickyDebug msg="homing_override going to home X"
 
         {% endif %}
 
         {% if 'Y' in params %}
             {% set home_y = True %}
-            _KlickyDebug msg="homing_override goint to home Y"
+            _KlickyDebug msg="homing_override going to home Y"
         {% endif %}
 
         {% if 'Z' in params %}
             {% set home_z = True %}
-            _KlickyDebug msg="homing_override goint to home Z"
+            _KlickyDebug msg="homing_override going to home Z"
         {% endif %}
 
         {% if 'X' in params
@@ -615,7 +615,7 @@ gcode:
             # reset homing state variables
             # if homing all axes
             _Homing_Variables reset=1
-            _KlickyDebug msg="homing_override goint to home all axes"
+            _KlickyDebug msg="homing_override going to home all axes"
          {% endif %}
 
     {% endif %}


### PR DESCRIPTION
simple typo fixes.