### PR TITLE
Avoid excess docking between z-tilt-adjust and rehoming z axis

### DIFF
--- a/Klipper_macros/klicky-z-tilt-adjust.cfg
+++ b/Klipper_macros/klicky-z-tilt-adjust.cfg
@@ -28,5 +28,5 @@ gcode:
     _Z_TILT_ADJUST {% for p in params
           %}{'%s=%s ' % (p, params[p])}{%
          endfor %}
-    Dock_Probe
     G28 Z0
+    Dock_Probe


### PR DESCRIPTION
Greetings, I noticed with the klicky macros, the probe is docked after _Z_TILT_ADJUST, and then immediately undocked to rehome Z-axis.
simply moving the rehoming of the Z-Axis before docking avoids this unnecessary docking/undocking.