### PR TITLE
Actuate servo before leaving safe z height

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -254,6 +254,9 @@ gcode:
 
             _Umbilical_Path
 
+            # if necessary do some actions before moving the toolhead to dock
+            _DeployKlickyDock
+
             _entry_point function=Attach_Probe_intern
 
             # Probe entry location
@@ -264,10 +267,8 @@ gcode:
                 G0 Z{docklocation_z|int - attachmove_z|int - attachmove2_z|int} F{dock_feedrate}
                 _KlickyDebug msg="Attach_Probe moving near the dock with G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}"
                 G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}
-				{% endif %}
-            # if necessary do some actions before moving the toolhead to dock
-            _DeployKlickyDock
-                              
+            {% endif %}
+
             # Drop Probe to Probe location
             {% if docklocation_z != -128 %}
                 _KlickyDebug msg="Attach_Probe moving to the dock with G0 Z{docklocation_z} F{dock_feedrate}"
@@ -284,13 +285,15 @@ gcode:
             {% endif %}
             _KlickyDebug msg="Attach_Probe moving from the dock to G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{release_feedrate}"
             G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{release_feedrate}
-            # if necessary do some actions after attaching the probe
-            _RetractKlickyDock
+
             ## Go to Z safe distance
             {% if ((printer.gcode_move.gcode_position.z < safe_z) or (docklocation_z != -128 and docklocation_z < safe_z ))%}
               _KlickyDebug msg="Attach_Probe moving to a safe Z position: G0 Z{safe_z} F{z_drop_feedrate} from {printer.gcode_move.gcode_position.z}"
               G0 Z{safe_z} F{z_drop_feedrate}
             {% endif %}
+
+            # if necessary do some actions after attaching the probe
+            _RetractKlickyDock
 
             _Park_Toolhead
 
@@ -370,6 +373,9 @@ gcode:
           {% endif %}
           _Umbilical_Path
 
+          # if necessary do some actions before moving the toolhead to dock
+          _DeployKlickyDock
+
           # Probe entry location
           _KlickyDebug msg="Dock_Probe moving near the dock with G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}"
           G0 X{docklocation_x|int - attachmove_x|int} Y{docklocation_y|int - attachmove_y|int} F{travel_feedrate}
@@ -378,9 +384,6 @@ gcode:
             _KlickyDebug msg="Dock_Probe moving near the dock with G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}"
             G0 Z{docklocation_z|int - attachmove_z|int} F{dock_feedrate}
           {% endif %}
-
-          # if necessary do some actions before moving the toolhead to dock
-          _DeployKlickyDock
 
           # Drop Probe to Probe location
           _KlickyDebug msg="Dock_Probe moving to the dock with G0 X{docklocation_x} Y{docklocation_y} F{dock_feedrate}"
@@ -400,9 +403,6 @@ gcode:
           _KlickyDebug msg="Dock_Probe moving from the dock to G0 X{docklocation_x|int + dockmove_x|int} Y{docklocation_y|int + dockmove_y|int} F{release_feedrate}"
           G0 X{docklocation_x|int + dockmove_x|int} Y{docklocation_y|int + dockmove_y|int} F{release_feedrate}
 
-          # if necessary do some actions after attaching the probe
-          _RetractKlickyDock
-
           #Do an extra move away
           _KlickyDebug msg="Dock_Probe moving away from the dock to G0 X{docklocation_x|int + dockmove_x|int - attachmove_x|int} Y{docklocation_y|int + dockmove_y|int - attachmove_y|int} F{release_feedrate}"
           G0 X{docklocation_x|int + dockmove_x|int - attachmove_x|int} Y{docklocation_y|int + dockmove_y|int - attachmove_y|int} F{release_feedrate}
@@ -412,6 +412,9 @@ gcode:
             _KlickyDebug msg="Dock_Probe moving to a safe Z position: G0 Z{safe_z} F{z_drop_feedrate} from {printer.gcode_move.gcode_position.z}"
             G0 Z{safe_z} F{z_drop_feedrate}
           {% endif %}
+
+          # if necessary do some actions after attaching the probe
+          _RetractKlickyDock
 
           _Park_Toolhead
 


### PR DESCRIPTION
`safe_z` should be used to avoid any interference with the dock servo.