### PR TITLE
Fix an issue where toolhead can crash on repeat homing because safe_z is being blindly overwritten with current z position

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -589,23 +589,23 @@ gcode:
         and not 'Z' in params %}
 
         {% set home_x, home_y, home_z = True, True, True %}
-        _KlickyDebug msg="homing_override goint to home all axes"
+        _KlickyDebug msg="homing_override going to home all axes"
 
     {% else %}
         {% if 'X' in params %}
             {% set home_x = True %}
-             _KlickyDebug msg="homing_override goint to home X"
+             _KlickyDebug msg="homing_override going to home X"
 
         {% endif %}
 
         {% if 'Y' in params %}
             {% set home_y = True %}
-            _KlickyDebug msg="homing_override goint to home Y"
+            _KlickyDebug msg="homing_override going to home Y"
         {% endif %}
 
         {% if 'Z' in params %}
             {% set home_z = True %}
-            _KlickyDebug msg="homing_override goint to home Z"
+            _KlickyDebug msg="homing_override going to home Z"
         {% endif %}
 
         {% if 'X' in params
@@ -614,7 +614,7 @@ gcode:
             # reset homing state variables
             # if homing all axes
             _Homing_Variables reset=1
-            _KlickyDebug msg="homing_override goint to home all axes"
+            _KlickyDebug msg="homing_override going to home all axes"
          {% endif %}
 
     {% endif %}
@@ -645,14 +645,16 @@ gcode:
             { action_respond_info("moving to a safe Z distance") }
         {% endif %}
         G0 Z{safe_z} F{z_drop_feedrate}
-	{% if home_z != True %} 
+    	{% if home_z != True %} 
           _KlickyDebug msg="homing_override clearing axis homed state if not already homing Z"
           M84
-        {% endif %}
+          {% endif %}
     {% else %}
         _KlickyDebug msg="All axis homed"
-        {% set safe_z = printer.gcode_move.gcode_position.z|float %}
-        _KlickyDebug msg="Setting Safe_z to {printer.gcode_move.gcode_position.z}mm as Z is now above configured safe_z"
+        {% if printer.gcode_move.gcode_position.z > safe_z %} 
+          {% set safe_z = printer.gcode_move.gcode_position.z|float %}
+          _KlickyDebug msg="Setting Safe_z to {printer.gcode_move.gcode_position.z}mm as Z is now above configured safe_z"
+        {% endif %}
     {% endif %}
 
     {% if home_z %}


### PR DESCRIPTION
Address an issue with blindly assuming that if Z is already homed then it is above safe_z which was overwriting the value of safe_z to the current Z position when re-homing if Z was already homed, regardless of whether the current position was actually above the safe_z. Additionally  included small typo fixes for logs.

Use case here is that because the machine is in a homed state, if my print fails or ends or any other action leaves my toolhead below specified safe_z height, the machine will not be returned to the actual safe_z when re homing because the code added in ac98aefb41dad7a62af7ded3610c21b70bca1efb will overwrite the user variable safe_z with whatever the current Z position is. Ideally we would want to do this only if the current Z is actually above configured safe_z