### PR TITLE
update klipper config folder location in README.md

### DIFF
--- a/Klipper_macros/README.md
+++ b/Klipper_macros/README.md
@@ -47,7 +47,7 @@ Some printers, like the Voron v0 or Tiny-M don't have the probe as a standard co
 Download the appropriate files (or the zip containing them all and delete the ones that are not relevant) and upload it to your klipper Config folder.
 
 ```bash
-cd ~/klipper_config/
+cd ~/printer_data/config
 wget https://raw.githubusercontent.com/jlas1/Klicky-Probe/main/Klipper_macros/Klipper_macros.zip
 unzip Klipper_macros.zip
 ```


### PR DESCRIPTION
### Changes
update klipper config folder location to `~/printer_data/config`


### Suggestion(but not in this pull)
I would also suggest making a sub folder named klicky to download and extract these to  and then change the include to...

[include ./klicky/klicky-probe.cfg]

but ill leave that up to you, I like a tidy config folder