### PR TITLE
fix: Restore LED to STATUS_HOMING after running Attach_Probe

### DIFF
--- a/Klipper_macros/klicky-macros.cfg
+++ b/Klipper_macros/klicky-macros.cfg
@@ -838,6 +838,7 @@ gcode:
     {% set verbose = printer["gcode_macro _User_Variables"].verbose %}
 
     _entry_point function=Home_Z
+    _KLICKY_STATUS_HOMING
 
     # if x and y are not homed yet, raise error
     {% if not 'xy' in printer.toolhead.homed_axes %}


### PR DESCRIPTION
Currently, the status LEDs are interupted by `STATUS_BUSY` when the `Attach_Probe` macro is performed, so the LEDs remain in the `STATUS_BUSY` mode while the Z is being homed. This change seeks to fix that by simply reapplying `STATUS_HOMING` during the Z homing override macro